### PR TITLE
fix displaying different backup destination filename

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -216,9 +216,11 @@ class BackupCommand extends Command
 
         $disk = Storage::disk($fileSystem);
 
-        $this->copyFile($file, $disk, $this->getBackupDestinationFileName(), $fileSystem == 'local');
+        $destBackupFilename = $this->getBackupDestinationFileName();
 
-        $this->comment('Backup stored on '.$fileSystem.'-filesystem in file "'.$this->getBackupDestinationFileName().'"');
+        $this->copyFile($file, $disk, $destBackupFilename, $fileSystem == 'local');
+
+        $this->comment('Backup stored on '.$fileSystem.'-filesystem in file "'.$destBackupFilename.'"');
     }
 
     /**


### PR DESCRIPTION
By calling `getBackupDestinationFileName()` twice, the actual destination backup filename will be different than the one displaying when backup finish. Specifically in the 'second' digit.