### PR TITLE
use Storage facade instead of alias

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -2,7 +2,7 @@
 
 use Exception;
 use Illuminate\Console\Command;
-use Storage;
+use Illuminate\Support\Facades\Storage;
 use Carbon\Carbon;
 use Spatie\Backup\FileHelpers\FileSelector;
 


### PR DESCRIPTION
Laravel 5 don't have Storage alias by default.