### PR TITLE
Allow to write directly into an S3 bucket

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -135,7 +135,9 @@ class BackupCommand extends Command
     {
         $destinationDirectory = dirname($destination);
 
-        $disk->makeDirectory($destinationDirectory);
+        if ($destinationDirectory != '.') {
+            $disk->makeDirectory($destinationDirectory);
+        }
 
         if ($addIgnoreFile) {
             $this->writeIgnoreFile($disk, $destinationDirectory);


### PR DESCRIPTION
When specifying a path in the config, dirname returns the name of the folder and makeDirectory ensures that this folder exists.

When the destination.path is empty, dirname returns a period "."

When makeDirectory is called with period as the directory name, AWS throws the exception.

A workaround is to skip the makeDirectory call when dirname returns a period.

Fixes #55.