### PR TITLE
Clarification of table headers

### DIFF
--- a/src/Commands/OverviewCommand.php
+++ b/src/Commands/OverviewCommand.php
@@ -48,6 +48,6 @@ class OverviewCommand extends Command
             }
         }
 
-        $this->table(['Name', 'Filesystem', 'Health', 'Amount of backups', 'Last backup', 'Used storage'], $backupOverview);
+        $this->table(['Name', 'Filesystem', 'Health', 'Number of backups', 'Last backup', 'Used storage'], $backupOverview);
     }
 }


### PR DESCRIPTION
I think "number of backups" is clearer as a header because "amount of backups" could imply volume, not quantity.