### PR TITLE
Better command path handling

### DIFF
--- a/src/BackupHandlers/Database/Databases/MySQLDatabase.php
+++ b/src/BackupHandlers/Database/Databases/MySQLDatabase.php
@@ -85,7 +85,11 @@ class MySQLDatabase implements DatabaseInterface
      */
     protected function getDumpCommandPath()
     {
-        return config('laravel-backup.mysql.dump_command_path');
+        if($path = config('laravel-backup.mysql.dump_command_path')) {
+            $path = str_finish($path, '/');
+        }
+
+        return $path;
     }
 
     /**

--- a/src/BackupHandlers/Database/Databases/PgSQLDatabase.php
+++ b/src/BackupHandlers/Database/Databases/PgSQLDatabase.php
@@ -77,7 +77,11 @@ class PgSQLDatabase implements DatabaseInterface
      */
     protected function getDumpCommandPath()
     {
-        return config('laravel-backup.pgsql.dump_command_path');
+        if($path = config('laravel-backup.pgsql.dump_command_path')) {
+            $path = str_finish($path, '/');
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
Current situation:
```php
// In Config
'dump_command_path' => '' -> Works
'dump_command_path' => 'path_without_slash' -> Fails **
'dump_command_path' => 'path_with_/' -> Works

** sprintf('%smysqldump ...', $this->getDumpCommandPath());
=> path_without_slashmysqldump
```` 

My PR fix that:
```php
'dump_command_path' => '' -> Works
'dump_command_path' => 'path_without_slash' -> Works **
'dump_command_path' => 'path_with_/' -> Works

** sprintf('%smysqldump ...', $this->getDumpCommandPath());
=> path_without_slash/mysqldump
```` 
