### PR TITLE
Custom dump_command_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-backup` will be documented in this file.
 
+### 3.1.3 - 2016-03-16
+
+- added an option to specify a custom mysqldump or pg_dump path, by adding "dump_path" in the database configuration file, for that particular database
+
 ### 3.1.2 - 2016-03-14
 
 - upped the required version of db-dumper to a bug free version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `laravel-backup` will be documented in this file.
 
 ### 3.1.3 - 2016-03-16
 
-- added an option to specify a custom mysqldump or pg_dump path, by adding "dump_path" in the database configuration file, for that particular database
+- added an option to specify a custom mysqldump or pg_dump path, by adding "dump_command_path" in the database configuration file, for that particular database
 
 ### 3.1.2 - 2016-03-14
 

--- a/src/Tasks/Backup/BackupJobFactory.php
+++ b/src/Tasks/Backup/BackupJobFactory.php
@@ -50,7 +50,7 @@ class BackupJobFactory
                 case 'mysql':
                     return MySql::create()
                         ->setHost($dbConfig['host'])
-                        ->setDumpBinaryPath(isset($dbConfig['dump_path'])?$dbConfig['dump_path']:'')
+                        ->setDumpBinaryPath(isset($dbConfig['dump_command_path'])?$dbConfig['dump_command_path']:'')
                         ->setDbName($dbConfig['database'])
                         ->setUserName($dbConfig['username'])
                         ->setPassword($dbConfig['password']);
@@ -59,7 +59,7 @@ class BackupJobFactory
                 case 'pgsql':
                     return PostgreSql::create()
                         ->setHost($dbConfig['host'])
-                        ->setDumpBinaryPath(isset($dbConfig['dump_path'])?$dbConfig['dump_path']:'')
+                        ->setDumpBinaryPath(isset($dbConfig['dump_command_path'])?$dbConfig['dump_command_path']:'')
                         ->setDbName($dbConfig['database'])
                         ->setUserName($dbConfig['username'])
                         ->setPassword($dbConfig['password']);

--- a/src/Tasks/Backup/BackupJobFactory.php
+++ b/src/Tasks/Backup/BackupJobFactory.php
@@ -50,6 +50,7 @@ class BackupJobFactory
                 case 'mysql':
                     return MySql::create()
                         ->setHost($dbConfig['host'])
+                        ->setDumpBinaryPath(isset($dbConfig['dump_path'])?$dbConfig['dump_path']:'')
                         ->setDbName($dbConfig['database'])
                         ->setUserName($dbConfig['username'])
                         ->setPassword($dbConfig['password']);
@@ -58,6 +59,7 @@ class BackupJobFactory
                 case 'pgsql':
                     return PostgreSql::create()
                         ->setHost($dbConfig['host'])
+                        ->setDumpBinaryPath(isset($dbConfig['dump_path'])?$dbConfig['dump_path']:'')
                         ->setDbName($dbConfig['database'])
                         ->setUserName($dbConfig['username'])
                         ->setPassword($dbConfig['password']);


### PR DESCRIPTION
In v2 you had the mysql.dump_command_path config variable, which was crucial for me.

I've added it in v3 too, but dump_command_path is now specified for each db in config/database.php, since you can now backup multiple databases and might want to define one for each db.

![database.php file screenshot](https://infinit.io/_/Txte2e3.png)

Tested and working for MySQL.
NOT TESTED but probably working for PostgreSql.

Cheers and keep up the good work!