### PR TITLE
Added the ability to change the pushover notification sounds

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -161,8 +161,12 @@ return [
          * Here you can specify how messages should be sent to Pushover.
          */
         'pushover' => [
-            'token' => env('PUSHOVER_APP_TOKEN'),
-            'user'  => env('PUSHOVER_USER_KEY'),
+            'token'  => env('PUSHOVER_APP_TOKEN'),
+            'user'   => env('PUSHOVER_USER_KEY'),
+            'sounds' => [
+                'success' => env('PUSHOVER_SOUND_SUCCESS','pushover'),
+                'error'   => env('PUSHOVER_SOUND_ERROR','siren'),
+            ],
         ],
     ]
 ];

--- a/src/Notifications/Senders/Pushover.php
+++ b/src/Notifications/Senders/Pushover.php
@@ -11,17 +11,6 @@ class Pushover extends BaseSender
     protected $config;
 
     /**
-     * Sounds the api supports by default
-     * @see https://pushover.net/api#sounds
-     * @var array
-     */
-    private $sounds = array(
-        'pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
-        'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
-        'persistent', 'echo', 'updown', 'none',
-    );
-
-    /**
      * @param Repository $config
      */
     public function __construct(Repository $config)
@@ -60,19 +49,7 @@ class Pushover extends BaseSender
 
         $sound = $this->type === static::TYPE_SUCCESS ? $sounds['success'] : $sounds['error'];
 
-        if(!$this->isSupportedSound($sound)){
-            $sound = 'pushover';
-        }
-
         return $sound;
     }
 
-    /**
-     * Checks if the sound is supported by Pushover
-     * @param  string  $sound The sound string to check
-     * @return boolean        [description]
-     */
-    private function isSupportedSound($sound){
-        return in_array($sound, $this->sounds);
-    }
 }

--- a/src/Notifications/Senders/Pushover.php
+++ b/src/Notifications/Senders/Pushover.php
@@ -11,6 +11,17 @@ class Pushover extends BaseSender
     protected $config;
 
     /**
+     * Sounds the api supports by default
+     * @see https://pushover.net/api#sounds
+     * @var array
+     */
+    private $sounds = array(
+        'pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
+        'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
+        'persistent', 'echo', 'updown', 'none',
+    );
+
+    /**
      * @param Repository $config
      */
     public function __construct(Repository $config)
@@ -18,6 +29,10 @@ class Pushover extends BaseSender
         $this->config = $config->get('laravel-backup.notifications.pushover');
     }
 
+    /**
+     * Sends the message to the Pushover API
+     * @return void
+     */
     public function send()
     {
         curl_setopt_array($ch = curl_init(), [
@@ -27,11 +42,37 @@ class Pushover extends BaseSender
                 'user' => $this->config['user'],
                 'title' => $this->subject,
                 'message' => $this->message,
-                'sound' => $this->type === static::TYPE_SUCCESS ? 'pushover' : 'siren',
+                'sound' => $this->getSound(),
             ],
             CURLOPT_SAFE_UPLOAD => true,
         ]);
         curl_exec($ch);
         curl_close($ch);
+    }
+
+    /**
+     * Returns the proper sound for the notification type according to the config file
+     * @return string The sound string to use
+     */
+    private function getSound()
+    {
+        $sounds = isset($this->config['sounds']) ? $this->config['sounds'] : ['success' => 'pushover', 'error' => 'siren'];
+
+        $sound = $this->type === static::TYPE_SUCCESS ? $sounds['success'] : $sounds['error'];
+
+        if(!$this->isSupportedSound($sound)){
+            $sound = 'pushover';
+        }
+
+        return $sound;
+    }
+
+    /**
+     * Checks if the sound is supported by Pushover
+     * @param  string  $sound The sound string to check
+     * @return boolean        [description]
+     */
+    private function isSupportedSound($sound){
+        return in_array($sound, $this->sounds);
     }
 }


### PR DESCRIPTION
I think one of Pushovers best features is its different notification sounds.

With this change I made sure it wont break anybody's existing implementation if they don`t have the new config settings
```php
'sounds' => [
        'success' => env('PUSHOVER_SOUND_SUCCESS','pushover'),
        'error' => env('PUSHOVER_SOUND_ERROR','siren'),
],
```

`Line #59` @ `src/Notifications/Senders/Pushover.php` Makes sure they wont break