### PR TITLE
Remove unnecessary output from curl when using pushover

### DIFF
--- a/src/Notifications/Senders/Pushover.php
+++ b/src/Notifications/Senders/Pushover.php
@@ -33,6 +33,7 @@ class Pushover extends BaseSender
                 'message' => $this->message,
                 'sound' => $this->getSound(),
             ],
+            CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SAFE_UPLOAD => true,
         ]);
         curl_exec($ch);


### PR DESCRIPTION
Whenever I manually execute `php artisan backup:run --only-db` CURL will output the response data when it sends a notification to Pushover.
`{"status":1,"request":"f37d781ad8db193852e660394254731f"}`

Before this change my output looks like this
```bash
Starting backup...
Dumping database testproject...
Determining files to backup...
Zipping 0 files...
Copying 2016-04-02-130218.zip (size: 15.25 MB) to disk named backups-local...
Successfully copied .zip file to disk named backups-local.
{"status":1,"request":"f37d781ad8db193852e660394254731f"}Copying 2016-04-02-130218.zip (size: 15.25 MB) to disk named backups-s3...
Successfully copied .zip file to disk named backups-s3.
{"status":1,"request":"67be53532fff0515ae5b3a57d0a6695d"}Backup completed!
```

With this change my output is much cleaner
```bash
Starting backup...
Dumping database testproject...
Determining files to backup...
Zipping 0 files...
Copying 2016-04-02-130612.zip (size: 15.25 MB) to disk named backups-local...
Successfully copied .zip file to disk named backups-local.
Copying 2016-04-02-130612.zip (size: 15.25 MB) to disk named backups-s3...
Successfully copied .zip file to disk named backups-s3.
Backup completed!
```