### PR TITLE
follow links

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -31,6 +31,11 @@ return [
                     base_path('node_modules'),
                     storage_path(),
                 ],
+
+                /*
+                 * Forces the following of symlinks if set to true.
+                 */
+                'followLinks' => false,
             ],
 
             /*

--- a/src/Tasks/Backup/BackupJobFactory.php
+++ b/src/Tasks/Backup/BackupJobFactory.php
@@ -32,7 +32,8 @@ class BackupJobFactory
     protected static function getFileSelection(array $sourceFiles)
     {
         return (new FileSelection($sourceFiles['include']))
-            ->excludeFilesFrom($sourceFiles['exclude']);
+            ->excludeFilesFrom($sourceFiles['exclude'])
+            ->shouldFollowLinks($sourceFiles['followLinks']);
     }
 
     /**

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -126,9 +126,12 @@ class FileSelection
         $finder = (new Finder())
             ->ignoreDotFiles(false)
             ->ignoreVCS(false)
-            ->followLinks()
             ->files()
             ->in($directory);
+
+        if (config('laravel-backup.backup.source.files.followLinks')) {
+            $finder->followLinks();
+        }
 
         $filePaths = array_map(function (SplFileInfo $fileInfo) {
             return $fileInfo->getPathname();

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -126,6 +126,7 @@ class FileSelection
         $finder = (new Finder())
             ->ignoreDotFiles(false)
             ->ignoreVCS(false)
+            ->followLinks()
             ->files()
             ->in($directory);
 

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -14,6 +14,9 @@ class FileSelection
     /** @var array */
     protected $excludeFilesAndDirectories = [];
 
+    /** @var bool */
+    protected $shouldFollowLinks = false;
+
     /**
      * @param array|string $includeFilesAndDirectories
      *
@@ -50,6 +53,20 @@ class FileSelection
         }
 
         $this->excludeFilesAndDirectories = $excludeFilesAndDirectories;
+
+        return $this;
+    }
+
+    /**
+     * Enable or disable the following of symlinks.
+     *
+     * @param bool $shouldFollowLinks
+     *
+     * @return \Spatie\Backup\Tasks\Backup\FileSelection
+     */
+    public function shouldFollowLinks($shouldFollowLinks)
+    {
+        $this->shouldFollowLinks = $shouldFollowLinks;
 
         return $this;
     }
@@ -129,7 +146,7 @@ class FileSelection
             ->files()
             ->in($directory);
 
-        if (config('laravel-backup.backup.source.files.followLinks')) {
+        if ($this->shouldFollowLinks) {
             $finder->followLinks();
         }
 


### PR DESCRIPTION
FileSelection now follows symlinks. This is useful if you use a deployment tool like [Capistrano](http://capistranorb.com/documentation/getting-started/structure/).