### PR TITLE
Added support for wildcards in the paths

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -25,6 +25,10 @@ return [
                 /*
                  * These directories will be excluded from the backup.
                  * You can specify individual files as well.
+                 *
+                 * You can use a wildcard (*) to exclude some paths. Example: */
+                 // base_path('public/media/*/conversions')
+                 /* This will exclude all media conversions in the backup.
                  */
                 'exclude' => [
                     base_path('vendor'),

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -91,6 +91,8 @@ class FileSelection
      */
     protected function getAllFilesFromPaths(array $paths)
     {
+        $paths = $this->checkForWildcardPaths($paths);
+
         $allFiles = collect($paths)
             ->filter(function ($path) {
                 return file_exists($path);
@@ -136,5 +138,23 @@ class FileSelection
         $filePaths = array_values($filePaths);
 
         return $filePaths;
+    }
+
+    /**
+     * Check all paths in array for a wildcard (*) and build a new array from the results.
+     *
+     * @param $paths
+     *
+     * @return array
+     */
+    private function checkForWildcardPaths($paths)
+    {
+        $paths_new = [];
+        foreach ($paths as $path) {
+            $paths_new[] = glob($path);
+        }
+        $paths_new = array_flatten($paths_new);
+
+        return $paths_new;
     }
 }

--- a/tests/Unit/FileSelectionTest.php
+++ b/tests/Unit/FileSelectionTest.php
@@ -57,6 +57,24 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_exclude_files_with_wildcards_from_a_given_subdirectory()
+    {
+        $fileSelection = (new FileSelection($this->sourceDirectory))
+            ->excludeFilesFrom("{$this->sourceDirectory}/*/directory1");
+
+        $this->assertSame(
+            $this->getTestFiles([
+                'directory1/file1.txt',
+                'directory1/file2.txt',
+                'file1.txt',
+                'file2.txt',
+                'file3.txt',
+            ]),
+            $fileSelection->getSelectedFiles()
+        );
+    }
+
+    /** @test */
     public function it_can_select_files_from_multiple_directories()
     {
         $fileSelection = (new FileSelection([


### PR DESCRIPTION
You can use a wildcard (*) in the include and exclude paths.
This is really useful in combination with https://github.com/spatie/laravel-medialibrary
Using a wildcard you're able to skip the backup of all the converted media. This will save a lot of backup storage in large projects.

example:
``` base_path('public/media/*/conversions') ```