### PR TITLE
Better FileSelection

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -157,9 +157,9 @@ class BackupJob
 
         $files = $this->fileSelection->getSelectedFiles();
 
-        consoleOutput()->info('Zipping '.count($files).' files...');
+        consoleOutput()->info("Zipping {$files->count()} files...");
 
-        $zip->add($files);
+        $zip->add($files->toArray());
     }
 
     /**

--- a/tests/Unit/FileSelectionTest.php
+++ b/tests/Unit/FileSelectionTest.php
@@ -35,7 +35,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file2.txt',
                 'file3.txt',
             ]),
-            $fileSelection->getSelectedFiles()
+            $fileSelection->getSelectedFiles()->toArray()
         );
     }
 
@@ -52,7 +52,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file2.txt',
                 'file3.txt',
             ]),
-            $fileSelection->getSelectedFiles()
+            $fileSelection->getSelectedFiles()->toArray()
         );
     }
 
@@ -70,7 +70,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file2.txt',
                 'file3.txt',
             ]),
-            $fileSelection->getSelectedFiles()
+            $fileSelection->getSelectedFiles()->toArray()
         );
     }
 
@@ -88,7 +88,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'directory1/directory1/file2.txt',
                 'directory2/directory1/file1.txt',
             ]),
-            $fileSelection->getSelectedFiles());
+            $fileSelection->getSelectedFiles()->toArray());
     }
 
     /** @test */
@@ -108,7 +108,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file1.txt',
                 'file3.txt',
             ]),
-            $fileSelection->getSelectedFiles()
+            $fileSelection->getSelectedFiles()->toArray()
         );
     }
 
@@ -117,7 +117,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
     {
         $fileSelection = new FileSelection('');
 
-        $this->assertEmpty($fileSelection->getSelectedFiles());
+        $this->assertEmpty($fileSelection->getSelectedFiles()->toArray());
     }
 
     /** @test */
@@ -126,7 +126,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
         $fileSelection = (new FileSelection($this->sourceDirectory))
             ->excludeFilesFrom($this->sourceDirectory);
 
-        $this->assertEmpty($fileSelection->getSelectedFiles());
+        $this->assertEmpty($fileSelection->getSelectedFiles()->toArray());
     }
 
     /** @test */


### PR DESCRIPTION
Currently the `FileSelection` class lists all files that are excluded, and filters them out of the included file list. This implementation doesn't list all the excluded files, but just checks the paths with `starts_with`.

This should greatly improve speed since file IO is expensive, and in turn reduce memory usage.

Bonus: `FileSelection` has been refactored to pass around collections instead of arrays, cleaning up the code a bit.