### PR TITLE
added support to --ignore-table mysqldump option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+phpunit.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-backup` will be documented in this file.
 
+### 3.7.3 - 2016-06-21
+
+- added support to mysql '--ignore-table' mysqldump option
+- added tests to mysqldump
+
 ### 3.7.2 - 2016-05-28
 
 - refactor `FileSelection` in an attempt to reduce memory usage

--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -44,6 +44,21 @@ return [
              */
             'databases' => [
                 'mysql',
+                
+                /*
+                * You can use some options to database backups
+                * includeTables - Incluide only these tables in backup
+                * excludeTables - Ingnore these tables in backup
+                * NOTE - You can't use includeTables and excludeTables at the same time.
+                * NOTE - Don't prefix the schema name. It'll be done automatically  
+                *'mysql' => [
+                *    'excludeTables' => [
+                *        'table_one' ,
+                *        'table_two'
+                *    ]
+                *]
+                * Currently only MySQL (includeTables and excludeTables) options are supported.
+                */
             ],
         ],
 

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -12,7 +12,7 @@ class BackupCommand extends BaseCommand
     /**
      * @var string
      */
-    protected $signature = 'backup:run {--only-db} {--only-files} {--only-to-disk=}';
+    protected $signature = 'backup:run {--only-db} {--only-files} {--only-to-disk=} {--exclude-tables=}';
 
     /**
      * @var string
@@ -26,7 +26,13 @@ class BackupCommand extends BaseCommand
         try {
             $this->guardAgainstInvalidOptions();
 
-            $backupJob = BackupJobFactory::createFromArray(config('laravel-backup'));
+            $options = [];
+
+            if ($this->option('exclude-tables')) {
+                $options['exclude-tables'] = explode( ',' , $this->option('exclude-tables') );
+            }
+
+            $backupJob = BackupJobFactory::createFromArray(config('laravel-backup') , $options);
 
             if ($this->option('only-db')) {
                 $backupJob->doNotBackupFilesystem();

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -91,4 +91,35 @@ class Zip
 
         return $this;
     }
+
+    /**
+     * @param string $fileName
+     *
+     * @return boolean
+     */
+    public function fileExists($fileName)
+    {
+        $this->open();
+
+        $index = $this->zipFile->locateName($fileName);
+    
+        $this->close();
+
+        return $index !== false;
+    }
+
+     /**
+     * @param string $fileName
+     *
+     * @return boolean
+     */
+    public function getFile($fileName)
+    {
+        $this->open();
+
+        $stream = $this->zipFile->getStream($fileName);
+        $this->close();
+
+        return $stream;
+    }
 }

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -2,10 +2,17 @@
 
 namespace Spatie\Backup\Test\Integration;
 
+use ZipArchive;
+use Spatie\Backup\Test\TestHelper;
+use Spatie\Backup\Tasks\Backup\Zip;
+use Spatie\DbDumper\Databases\MySql;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
 
 class BackupCommandTest extends TestCase
 {
+     protected $testHelper;
+
     public function setUp()
     {
         parent::setUp();
@@ -14,6 +21,8 @@ class BackupCommandTest extends TestCase
             'local',
             'secondLocal',
         ]);
+
+        $this->testHelper = new TestHelper();
     }
 
     /** @test */
@@ -60,12 +69,123 @@ class BackupCommandTest extends TestCase
     /** @test */
     public function it_will_fail_when_trying_to_backup_a_non_existing_database()
     {
-        //since our test environment did not set up a db, this will fail
+        //as you must have a valid mysql database setted to get green in some other tests, you must invalidate this setting. 
+        config(['database.connections.mysql.database' => 'this_db_does_not_exists']);
+
         $resultCode = Artisan::call('backup:run', [
             '--only-db' => true,
         ]);
 
         $this->seeInConsoleOutput('Backup failed');
+    }
+
+    /** @test */
+    public function it_can_backup_an_existing_mysql_database()
+    {
+        $resultCode = Artisan::call('backup:run', [
+            '--only-db' => true,
+        ]);
+
+        $fileName = env('DB_DATABASE').'.sql';
+
+        $pathToZip = $this->testHelper->getFirstZipFileFromPath( 'mysite.com', 'local' );
+
+        $this->assertFileExistsInZipFile( $fileName, $pathToZip );
+        
+    }
+
+    /** @test */
+    public function it_backups_by_default_from_a_mysql_database()
+    {
+        
+        MySql::dropTables();
+
+        $resultCode = Artisan::call('migrate', [
+            '--database' => 'mysql',
+            '--realpath' => $this->testHelper->getMigrationDirectory()
+        ]);
+
+        $resultCode = Artisan::call('backup:run', [
+            '--only-db' => true,
+        ]);
+
+        $fileName = env('DB_DATABASE').'.sql';
+
+        $pathToZip = $this->testHelper->getFirstZipFileFromPath( 'mysite.com', 'local' );
+
+        $zip = new Zip( $pathToZip );
+
+        $fileContent = stream_get_contents($zip->getFile( $fileName ));
+
+        $this->assertContains( '`migrations`', $fileContent );
+        $this->assertContains( '`table_1`', $fileContent );
+        $this->assertContains( '`table_2`', $fileContent );
+        
+    }
+
+    /** @test */
+    public function it_can_ingore_tables_when_backups_a_mysql_database_using_config_file_settings()
+    {
+
+        $this->app['config']->set('laravel-backup.backup.source.databases.mysql', [
+            'excludeTables' => [
+                'table_1' ,
+                'table_2'
+            ]
+        ]);
+        
+        MySql::dropTables();
+
+        $resultCode = Artisan::call('migrate', [
+            '--database' => 'mysql',
+            '--realpath' => $this->testHelper->getMigrationDirectory()
+        ]);
+
+        $resultCode = Artisan::call('backup:run', [
+            '--only-db' => true,
+        ]);
+
+        $fileName = env('DB_DATABASE').'.sql';
+
+        $pathToZip = $this->testHelper->getFirstZipFileFromPath( 'mysite.com', 'local' );
+
+        $zip = new Zip( $pathToZip );
+
+        $fileContent = stream_get_contents($zip->getFile( $fileName ));
+
+        $this->assertContains( '`migrations`', $fileContent );
+        $this->assertNotContains( '`table_1`', $fileContent );
+        $this->assertNotContains( '`table_2`', $fileContent );
+        
+    }
+
+    /** @test */
+    public function it_can_ingore_tables_when_backups_a_mysql_database_using_artisan_parameters()
+    {
+        MySql::dropTables();
+
+        $resultCode = Artisan::call('migrate', [
+            '--database' => 'mysql',
+            '--realpath' => $this->testHelper->getMigrationDirectory()
+        ]);
+
+        $resultCode = Artisan::call('backup:run', [
+            '--only-db' => true,
+            '--exclude-tables' => 'table_1,table_2'
+        ]);
+
+        $fileName = env('DB_DATABASE').'.sql';
+
+        $pathToZip = $this->testHelper->getFirstZipFileFromPath( 'mysite.com', 'local' );
+
+        $zip = new Zip( $pathToZip );
+
+        $fileContent = stream_get_contents($zip->getFile( $fileName ));
+
+        $this->assertContains( '`migrations`', $fileContent );
+        $this->assertNotContains( '`table_1`', $fileContent );
+        $this->assertNotContains( '`table_2`', $fileContent );
+        
     }
 
     /** @test */

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -4,12 +4,13 @@ namespace Spatie\Backup\Test\Integration;
 
 use Event;
 use Exception;
-use Illuminate\Contracts\Console\Kernel;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Storage;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Spatie\Backup\BackupServiceProvider;
 use Spatie\Backup\Test\TestHelper;
+use Spatie\Backup\Tasks\Backup\Zip;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Contracts\Console\Kernel;
+use Spatie\Backup\BackupServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
+use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
@@ -75,7 +76,35 @@ abstract class TestCase extends Orchestra
         });
 
         TestModel::create(['name' => 'test']);
+        
     }
+
+    /**
+     * @param string $directory
+     * @param string $pathToZip
+     */
+    protected function assertFileExistsInZipFile( $fileName, $pathToZip )
+    {
+        $zip = new Zip($pathToZip);
+        
+        $fileExists = $zip->fileExists( $fileName );
+             
+        $this->assertEquals( true , $fileExists );
+    } 
+
+    /**
+     * @param string $directory
+     * @param string $pathToZip
+     */
+    protected function assertFileDoesNotExistsInZipFile( $fileName, $pathToZip )
+    {
+        $zip = new Zip($pathToZip);
+        
+        $fileExists = $zip->fileExists( $fileName );
+             
+        $this->assertEquals( false , $fileExists );
+    }
+
 
     /**
      * @param string $extension
@@ -168,4 +197,5 @@ abstract class TestCase extends Orchestra
 
         $this->assertNotContains($unExpectedText, $consoleOutput, "Did not expect to see `{$unExpectedText}` in console output: `$consoleOutput`");
     }
+
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -3,7 +3,9 @@
 namespace Spatie\Backup\Test;
 
 use DateTime;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
 
 class TestHelper
 {
@@ -50,6 +52,12 @@ class TestHelper
         return __DIR__.'/temp';
     }
 
+    public function getMigrationDirectory()
+    {
+        return __DIR__.'/migrations';
+    }
+
+    
     public function createTempFileWithAge($fileName, DateTime $date, $contents = '')
     {
         $directory = $this->getTempDirectory().'/'.dirname($fileName);
@@ -62,4 +70,35 @@ class TestHelper
 
         touch($fullPath, $date->getTimeStamp());
     }
+
+    /**
+     * @param string $directory
+     * @param string $diskName
+     */
+    public function getFirstZipFileFromPath( $directory, $diskName )
+    {
+
+        $files = Storage::disk( $diskName )->files( $directory );
+
+        $filePath = '';
+
+        foreach ($files as $file) {
+            if( pathinfo($file, PATHINFO_EXTENSION) == 'zip' )
+            {
+                $filePath = $file;
+                break;
+            }
+        }
+        
+        if( empty($filePath))
+        {
+            return false;
+        }
+
+        $pathToZip = Storage::disk('local')->getDriver()->getAdapter()->getPathPrefix().$filePath;
+
+        return $pathToZip;
+    }
+
+   
 }

--- a/tests/Unit/ZipTest.php
+++ b/tests/Unit/ZipTest.php
@@ -2,21 +2,15 @@
 
 namespace Spatie\Backup\Test\Unit;
 
-use Spatie\Backup\Tasks\Backup\Zip;
 use Spatie\Backup\Test\TestHelper;
+use Spatie\Backup\Tasks\Backup\Zip;
+use Spatie\Backup\Test\Integration\TestCase;
 
-class ZipTest extends \PHPUnit_Framework_TestCase
+class ZipTest extends TestCase
 {
-    /**
-     * @var \Spatie\Backup\Test\TestHelper
-     */
-    protected $testHelper;
-
     public function setUp()
     {
         parent::setUp();
-
-        $this->testHelper = new TestHelper();
 
         $this->testHelper->initializeTempDirectory();
     }
@@ -31,5 +25,57 @@ class ZipTest extends \PHPUnit_Framework_TestCase
         $zip->add(__FILE__);
 
         $this->assertFileExists($pathToZip);
+    }
+
+    /** @test */
+    public function it_can_say_that_a_file_is_inside_a_zip_file()
+    {
+        $pathToZip = "{$this->testHelper->getTempDirectory()}/test.zip";
+
+        $zip = new Zip($pathToZip);
+
+        $zip->add(__FILE__);
+
+        $fileName = __FILE__;
+
+        $this->assertFileExistsInZipFile( $fileName , $pathToZip );
+
+    }
+
+    /** @test */
+    public function it_can_say_that_a_file_is_not_inside_a_zip_file()
+    {
+        $pathToZip = "{$this->testHelper->getTempDirectory()}/test.zip";
+
+        $zip = new Zip($pathToZip);
+
+        $fileName = __FILE__;
+
+        $zip->add($fileName);
+        
+        #change the file name. 
+        $fileName .="x";
+
+        $this->assertFileDoesNotExistsInZipFile( $fileName , $pathToZip );
+
+    }
+
+    /** @test */
+    public function it_can_get_a_file_from_a_zip_file()
+    {
+        $pathToZip = "{$this->testHelper->getTempDirectory()}/test.zip";
+
+        $zip = new Zip($pathToZip);
+
+        $fileName = __FILE__;
+
+        $zip->add($fileName);
+        
+        $file = $zip->getFile( $fileName );
+
+        $isStream = $file !== false;
+
+        $this->assertEquals( true, $isStream );
+
     }
 }

--- a/tests/migrations/2016_06_20_00000000_create_table_1_table.php
+++ b/tests/migrations/2016_06_20_00000000_create_table_1_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTable1Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('table_1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('table_1');
+    }
+}

--- a/tests/migrations/2016_06_20_00000000_create_table_2_table.php
+++ b/tests/migrations/2016_06_20_00000000_create_table_2_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTable2Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('table_2', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('table_2');
+    }
+}


### PR DESCRIPTION
I've added an option to ignore some tables on MySql backups.

It can be done by adding an array with options to databases key
```
/*
+                * You can use some options to database backups
+                * includeTables - Incluide only these tables in backup
+                * excludeTables - Ingnore these tables in backup
+                * NOTE - You can't use includeTables and excludeTables at the same time.
+                * NOTE - Don't prefix the schema name. It'll be done automatically  
+                *'mysql' => [
+                *    'excludeTables' => [
+                *        'table_one' ,
+                *        'table_two'
+                *    ]
+                *]
+                * Currently only MySQL (includeTables and excludeTables) options are supported.
+                */
```

 in config file or to artisan command 

`php artisan backup:run --excluide-tables=table_1,table2`

I've also created some mysqldump tests. You must have a mysql server running to run the tests know