### PR TITLE
Cache composer, test on 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 env:
   matrix:
@@ -12,7 +19,7 @@ env:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:
   - phpunit --coverage-text --coverage-clover=coverage.clover


### PR DESCRIPTION
This will cache the composer downloads as zip, which makes the tests run faster.

Also added 7.1 to the matrix.