### PR TITLE
Use read database connection if available

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -18,8 +18,10 @@ class DbDumperFactory
     {
         $dbConfig = config("database.connections.{$dbConnectionName}");
 
+        $dbHost = array_get($dbConfig, 'read.host', array_get($dbConfig, 'host'));
+
         $dbDumper = static::forDriver($dbConfig['driver'])
-            ->setHost($dbConfig['host'])
+            ->setHost($dbHost)
             ->setDbName($dbConfig['database'])
             ->setUserName($dbConfig['username'])
             ->setPassword($dbConfig['password']);

--- a/tests/Unit/DbDumperFactoryTest.php
+++ b/tests/Unit/DbDumperFactoryTest.php
@@ -36,6 +36,28 @@ class DbDumperFactoryTest extends TestCase
     }
 
     /** @test */
+    public function it_uses_the_read_db_for_instances_of_mysql_and_pgsql()
+    {
+        $dbConfig = [
+            'driver' => 'mysql',
+            'read' => [
+                'host' => 'localhost',
+            ],
+            'write' => [
+                'host' => 'localhost',
+            ],
+            'username' => 'root',
+            'password' => 'myPassword',
+            'database' => 'myDb',
+            'dump' => ['add_extra_option' => '--extra-option=value'],
+        ];
+
+        $this->app['config']->set('database.connections.mysql', $dbConfig);
+        $this->assertInstanceOf(MySql::class, DbDumperFactory::createFromConnection('mysql'));
+        $this->assertInstanceOf(PostgreSql::class, DbDumperFactory::createFromConnection('pgsql'));
+    }
+
+    /** @test */
     public function it_will_throw_an_exception_when_creating_an_unknown_type_of_dumper()
     {
         $this->expectException(CannotCreateDbDumper::class);


### PR DESCRIPTION
This PR fixes issue #163 
If a read database host is available, this will be used.
Otherwise, it will fall back to the default host key.