### PR TITLE
Make backup filename configurable

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -49,6 +49,11 @@ return [
         'destination' => [
 
             /*
+             * The filename prefix used for the backup zip file.
+             */
+            'filename_prefix' => '',
+
+            /*
              * The disk names on which the backups will be stored.
              */
             'disks' => [

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -169,7 +169,7 @@ class BackupJob
     {
         consoleOutput()->info("Zipping {$manifest->count()} files...");
 
-        $pathToZip = $this->temporaryDirectory->path(Carbon::now()->format('Y-m-d-H-i-s').'.zip');
+        $pathToZip = $this->temporaryDirectory->path(config('laravel-backup.backup.destination.filename_prefix').Carbon::now()->format('Y-m-d-H-i-s').'.zip');
 
         $zip = Zip::createForManifest($manifest, $pathToZip);
 

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -42,6 +42,26 @@ class BackupCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_can_backup_using_a_custom_filename()
+    {
+        $this->date = Carbon::create('2016', 1, 1, 9, 1, 1);
+
+        Carbon::setTestNow($this->date);
+
+        $this->app['config']->set('laravel-backup.backup.destination.filename_prefix', 'custom_name_');
+
+        $this->expectedZipPath = 'mysite.com/custom_name_2016-01-01-09-01-01.zip';
+
+        $resultCode = Artisan::call('backup:run', ['--only-files' => true]);
+
+        $this->assertEquals(0, $resultCode);
+
+        $this->assertFileExistsOnDisk($this->expectedZipPath, 'local');
+
+        $this->assertFileExistsOnDisk($this->expectedZipPath, 'secondLocal');
+    }
+
+    /** @test */
     public function it_can_backup_to_a_specific_disk()
     {
         $resultCode = Artisan::call('backup:run', [


### PR DESCRIPTION
This PR addresses issue #277 and allows the user to change the backup filename in the configuration.
I decided against putting the filename in the artisan command, because you have more control over it within the configuration file.

I needed to reset the config values in the test, because otherwise Carbon would return the previously used date.
