### PR TITLE
Encrypt backups

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -59,7 +59,7 @@ return [
         /*
          * Encrypt the final zip file using Laravel Crypt
          */
-        'encrypt' => false
+        'encrypt' => false,
     ],
 
 

--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -55,6 +55,11 @@ return [
                 'local',
             ],
         ],
+
+        /*
+         * Encrypt the final zip file using Laravel Crypt
+         */
+        'encrypt' => false
     ],
 
 

--- a/src/Tasks/Backup/BackupJobFactory.php
+++ b/src/Tasks/Backup/BackupJobFactory.php
@@ -12,6 +12,7 @@ class BackupJobFactory
         return (new BackupJob())
             ->setFileSelection(static::createFileSelection($config['backup']['source']['files']))
             ->setDbDumpers(static::createDbDumpers($config['backup']['source']['databases']))
+            ->setEncryption($config['backup']['encrypt'])
             ->setBackupDestinations(BackupDestinationFactory::createFromArray($config['backup']));
     }
 

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Backup\Test\Integration;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Artisan;
 
 class BackupCommandTest extends TestCase
@@ -140,5 +141,25 @@ class BackupCommandTest extends TestCase
         Artisan::call('backup:run');
 
         $this->seeInConsoleOutput('There are no files to be backed up');
+    }
+    
+    /** @test */
+    public function it_will_not_encrypt_when_configured_not_to()
+    {
+        $this->app['config']->set('laravel-backup.backup.encrypt', false);
+        
+        Crypt::shouldReceive('encrypt')->never();
+        
+        Artisan::call('backup:run');
+    }
+        
+    /** @test */
+    public function it_will_encrypt_when_configured_to()
+    {
+        $this->app['config']->set('laravel-backup.backup.encrypt', true);
+        
+        Crypt::shouldReceive('encrypt')->once();
+        
+        Artisan::call('backup:run');
     }
 }

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -142,24 +142,24 @@ class BackupCommandTest extends TestCase
 
         $this->seeInConsoleOutput('There are no files to be backed up');
     }
-    
+
     /** @test */
     public function it_will_not_encrypt_when_configured_not_to()
     {
         $this->app['config']->set('laravel-backup.backup.encrypt', false);
-        
+
         Crypt::shouldReceive('encrypt')->never();
-        
+
         Artisan::call('backup:run');
     }
-        
+
     /** @test */
     public function it_will_encrypt_when_configured_to()
     {
         $this->app['config']->set('laravel-backup.backup.encrypt', true);
-        
+
         Crypt::shouldReceive('encrypt')->once();
-        
+
         Artisan::call('backup:run');
     }
 }


### PR DESCRIPTION
So from the discussion here https://github.com/spatie/laravel-backup/issues/298

I've made a basic PR for this, to show how simple it is. I've tested it, and it works perfectly. You can toggle encryption on/off in the config (default is off).

Encrypts the whole file prior to putting it in the various destination folders.

I feel this is a great addition to the package, so hopefully this (or a variation of) can be included...