### PR TITLE
Updated BaseNotification to return all values as string.

### DIFF
--- a/src/Notifications/BaseNotification.php
+++ b/src/Notifications/BaseNotification.php
@@ -44,7 +44,7 @@ abstract class BaseNotification extends Notification
             'Application name' => $this->applicationName(),
             'Disk' => $backupDestination->diskName(),
             'Newest backup size' => $newestBackup ? Format::humanReadableSize($newestBackup->size()) : 'No backups were made yet',
-            'Amount of backups' => $backupDestination->backups()->count(),
+            'Amount of backups' => strval($backupDestination->backups()->count()),
             'Total storage used' => Format::humanReadableSize($backupDestination->backups()->size()),
             'Newest backup date' => $newestBackup ? $newestBackup->date()->format('Y/m/d H:i:s') : 'No backups were made yet',
             'Oldest backup date' => $oldestBackup ? $oldestBackup->date()->format('Y/m/d H:i:s') : 'No backups were made yet',


### PR DESCRIPTION
Some slack-like tools (like mattermost) don't parse json as cleanly as slack does.