### PR TITLE
Throw errors caught from backupjob up the chain to backup command

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -155,6 +155,7 @@ class BackupJob
             consoleOutput()->error("Backup failed because {$exception->getMessage()}.");
 
             event(new BackupHasFailed($exception));
+            throw $exception; // Let the exception continue up to the BackupCommand.
         }
     }
 


### PR DESCRIPTION
First off, apologies about this being against v3.  I still have apps that require php5.5.

Not sure if this is the best fix, but I was running into issues with calling backup:run from an Artisan::call() because exceptions thrown would not make it all the way to backupcommand (they'd be caught by the job).  This, along with   https://github.com/spatie/db-dumper/pull/28, should allow for displaying of an error when the dump executable is not found in path.

There may be a cleaner way to do it, but this happened to work :)