### PR TITLE
Fix version  constraints for package spatie/temporary-directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/notifications": "~5.3.28|~5.4.0",
         "league/flysystem": "^1.0.27",
         "spatie/db-dumper": "^2.1",
-        "spatie/temporary-directory": "~1.0.0",
+        "spatie/temporary-directory": "~1.0",
         "symfony/finder": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Version constraints for `spatie/temporary-directory` was set to `~1.0.0`, which prevented composer from resolving the latest release of the package. Setting it to `~1.0` allows to depends on any `1.x`version. 

Fix  https://github.com/spatie/laravel-backup/issues/358