### PR TITLE
Force BackupDestinationStatus::maximumAllowedUsageInBytes() to return an integer

### DIFF
--- a/src/Tasks/Monitor/BackupDestinationStatus.php
+++ b/src/Tasks/Monitor/BackupDestinationStatus.php
@@ -108,7 +108,7 @@ class BackupDestinationStatus
 
     public function maximumAllowedUsageInBytes(): int
     {
-        return $this->maximumStorageUsageInMegabytes * 1024 * 1024;
+        return (int) ($this->maximumStorageUsageInMegabytes * 1024 * 1024);
     }
 
     public function usesTooMuchStorage(): bool


### PR DESCRIPTION
As described in https://github.com/spatie/laravel-backup/issues/351#issuecomment-277183330 this PR forces the return type of `BackupDestinationStatus::maximumAllowedUsageInBytes()` to be an integer, even on platforms (armv7l) where it might be converted to a float.