### PR TITLE
Trim starting `/` from filepath in backup archive to avoid empty root directory

### DIFF
--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -100,7 +100,7 @@ class Zip
 
         foreach ($files as $file) {
             if (file_exists($file)) {
-                $this->zipFile->addFile($file, $nameInZip).PHP_EOL;
+                $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR)).PHP_EOL;
             }
             $this->fileCount++;
         }


### PR DESCRIPTION
This should fix #367.