### PR TITLE
Updated composer.json v3 to be compatible Laravel 5.4 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php" : "^5.5|^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0",
-        "illuminate/console": "~5.1.0|~5.2.0|~5.3.0",
-        "illuminate/filesystem": "~5.1.20|~5.2.0|~5.3.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/console": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/filesystem": "~5.1.20|~5.2.0|~5.3.0|~5.4.0",
         "league/flysystem": "^1.0.8",
         "symfony/finder": "^2.7|^3.0",
         "spatie/db-dumper": "^1.3"


### PR DESCRIPTION
I noticed an issue regarding the `exclude` array while running Laravel 5.4 with PHP < 7. The folders listed in the `exclude` array aren't excluded. This results in massively increasing backup files. The problem is described in #378 as well.

So I updated the `composer.json` in v3 to be compatible with Laravel 5.4 too.
My backups worked fine afterwards. The `exclude` folders are excluded as desired. ;)