### PR TITLE
Using badge-poser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A modern backup solution for Laravel apps
 
-[![Latest Version](https://img.shields.io/github/release/spatie/laravel-backup.svg?style=flat-square)](https://github.com/spatie/laravel-backup/releases)
+[![Latest Stable Version](https://poser.pugx.org/spatie/laravel-backup/v/stable?format=flat-square)](https://packagist.org/packages/spatie/laravel-backup)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/laravel-backup/master.svg?style=flat-square)](https://travis-ci.org/spatie/laravel-backup)
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/3f243a38-a1c7-42f5-96c8-37526e807029.svg?style=flat-square)](https://insight.sensiolabs.com/projects/3f243a38-a1c7-42f5-96c8-37526e807029)


### PR DESCRIPTION
Using badge-poser and packagist to show the latest stable version instead of the latest release in `README.md`. So the v3 releases won't be in the badge event if they are newer than a v4 release.