### PR TITLE
Check for empty string in notifications config

### DIFF
--- a/src/Notifications/BaseNotification.php
+++ b/src/Notifications/BaseNotification.php
@@ -15,7 +15,13 @@ abstract class BaseNotification extends Notification
      */
     public function via()
     {
-        return config('laravel-backup.notifications.notifications.'.static::class);
+        $notificationChannels = config('laravel-backup.notifications.notifications.'.static::class);
+
+        if (empty($notificationChannels) || empty($notificationChannels[0])) {
+            return [];
+        }
+
+        return $notificationChannels;
     }
 
     public function applicationName(): string


### PR DESCRIPTION
If an array with an empty string `[""]` or simply an empty string `""` is used as the notification channel we'll default it to an empty array `[]` so Laravel doesn't get confused and starts sending mails.

This should fix #355 