### PR TITLE
fix there is an errro when backup with some adapter fclose the resource internally

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -81,7 +81,9 @@ class BackupDestination
 
         $this->disk->getDriver()->writeStream($destination, $handle);
 
-        fclose($handle);
+        if (is_resource($handle)) {
+            fclose($handle);
+        }
     }
 
     public function backupName(): string


### PR DESCRIPTION
```
Copying zip failed because: fclose(): supplied resource is not a valid stream resource.
```
with this error it also can work fine 😊