### PR TITLE
Use configured charset when dumping database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-backup` will be documented in this file.
 
+## 4.8.1 - 2017-04-06
+- dump mysql databases in the configured charset
+
 ## 4.8.0 - 2017-04-02
 - add Arabic translation
 

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -27,6 +27,10 @@ class DbDumperFactory
             ->setUserName($dbConfig['username'] ?? '')
             ->setPassword($dbConfig['password'] ?? '');
 
+        if ($dbDumper instanceof MySql) {
+            $dbDumper->setDefaultCharacterSet($dbConfig['charset'] ?? '');
+        }
+
         if (isset($dbConfig['port'])) {
             $dbDumper = $dbDumper->setPort($dbConfig['port']);
         }


### PR DESCRIPTION
The `setDefaultCharacterSet` method will be used for `MySql` dumper instances to set the charset to the configured value in `database.php`.

Fixes #411 