### PR TITLE
Optimise backup:list for external file systems

### DIFF
--- a/src/BackupDestination/BackupCollection.php
+++ b/src/BackupDestination/BackupCollection.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Collection;
 
 class BackupCollection extends Collection
 {
+    /** @var null|int */
+    protected $sizeCache = null;
+
     /**
      * @param \Illuminate\Contracts\Filesystem\Filesystem|null $disk
      * @param array                                            $files
@@ -49,7 +52,11 @@ class BackupCollection extends Collection
 
     public function size(): int
     {
-        return $this->sum(function (Backup $backup) {
+        if ($this->sizeCache !== null) {
+            return $this->sizeCache;
+        }
+
+        return $this->sizeCache = $this->sum(function (Backup $backup) {
             return $backup->size();
         });
     }

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -22,6 +22,9 @@ class BackupDestination
     /** @var Exception */
     public $connectionError;
 
+    /** @var null|\Spatie\Backup\BackupDestination\BackupCollection */
+    protected $backupCollection = null;
+
     public function __construct(Filesystem $disk = null, string $backupName, string $diskName)
     {
         $this->disk = $disk;
@@ -93,9 +96,13 @@ class BackupDestination
 
     public function backups(): BackupCollection
     {
-        $files = $this->isReachable() ? $this->disk->allFiles($this->backupName) : [];
+        if ($this->backupCollection) {
+            return $this->backupCollection;
+        }
 
-        return BackupCollection::createFromFiles(
+        $files = is_null($this->disk) ? [] : $this->disk->allFiles($this->backupName);
+
+        return $this->backupCollection = BackupCollection::createFromFiles(
             $this->disk,
             $files
         );

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -23,7 +23,7 @@ class BackupDestination
     public $connectionError;
 
     /** @var null|\Spatie\Backup\BackupDestination\BackupCollection */
-    protected $backupCollection = null;
+    protected $backupCollectionCache = null;
 
     public function __construct(Filesystem $disk = null, string $backupName, string $diskName)
     {
@@ -96,13 +96,13 @@ class BackupDestination
 
     public function backups(): BackupCollection
     {
-        if ($this->backupCollection) {
-            return $this->backupCollection;
+        if ($this->backupCollectionCache) {
+            return $this->backupCollectionCache;
         }
 
         $files = is_null($this->disk) ? [] : $this->disk->allFiles($this->backupName);
 
-        return $this->backupCollection = BackupCollection::createFromFiles(
+        return $this->backupCollectionCache = BackupCollection::createFromFiles(
             $this->disk,
             $files
         );

--- a/src/Tasks/Monitor/BackupDestinationStatus.php
+++ b/src/Tasks/Monitor/BackupDestinationStatus.php
@@ -124,7 +124,7 @@ class BackupDestinationStatus
 
     public function isHealthy(): bool
     {
-        if (! $this->backupDestination->isReachable()) {
+        if (! $this->isReachable()) {
             return false;
         }
 


### PR DESCRIPTION
I noticed running `backup:list` with 2 backups on a disk generated about 90 filesystem API requests.

This PR caches the `BackupCollection` and the `BackupCollection` size when running the `backup:list` command and brings that number down to 20 API requests.

![screen shot 2017-04-19 at 15 27 11](https://cloud.githubusercontent.com/assets/6287961/25182663/ac153694-2515-11e7-86c1-ef993dc3bb45.png)

(still not ideal but this could be further improved by using [memory caching](https://flysystem.thephpleague.com/caching/) when the adapter is registered in the application)