### PR TITLE
Add feature to optionally gzip dumped .sql

### DIFF
--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -46,6 +46,11 @@ return [
             ],
         ],
 
+        /*
+         * Gzip the dumped SQL files for extra compression
+         */
+        'gzipSql' => false,
+
         'destination' => [
 
             /*

--- a/config/laravel-backup.php
+++ b/config/laravel-backup.php
@@ -49,7 +49,7 @@ return [
         /*
          * Gzip the dumped SQL files for extra compression
          */
-        'gzipSql' => false,
+        'gzip_sql' => false,
 
         'destination' => [
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -4,8 +4,8 @@ namespace Spatie\Backup\Tasks\Backup;
 
 use Exception;
 use Carbon\Carbon;
-use Spatie\Backup\Helpers\Format;
 use Spatie\DbDumper\DbDumper;
+use Spatie\Backup\Helpers\Format;
 use Illuminate\Support\Collection;
 use Spatie\Backup\Events\BackupHasFailed;
 use Spatie\Backup\Events\BackupWasSuccessful;
@@ -219,31 +219,31 @@ class BackupJob
     {
         consoleOutput()->info("Gzipping {$dbDumper->getDbName()}...");
 
-        $gzipPath = $temporaryFilePath . '.gz';
+        $gzipPath = $temporaryFilePath.'.gz';
 
         if ($gzipOut = gzopen($gzipPath, 'w9')) {
             if ($gzipIn = fopen($temporaryFilePath, 'rb')) {
-                while (!feof($gzipIn)) {
+                while (! feof($gzipIn)) {
                     gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
                 }
                 fclose($gzipIn);
             } else {
                 consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
+
                 return $temporaryFilePath;
             }
 
             gzclose($gzipOut);
         } else {
             consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
+
             return $temporaryFilePath;
         }
 
-        consoleOutput()->info("Gzipped {$dbDumper->getDbName()} from ".Format::humanReadableSize(filesize($temporaryFilePath))." to ".Format::humanReadableSize(filesize($gzipPath)));
+        consoleOutput()->info("Gzipped {$dbDumper->getDbName()} from ".Format::humanReadableSize(filesize($temporaryFilePath)).' to '.Format::humanReadableSize(filesize($gzipPath)));
 
         return $gzipPath;
     }
-
-
 
     protected function copyToBackupDestinations(string $path)
     {

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -4,6 +4,7 @@ namespace Spatie\Backup\Tasks\Backup;
 
 use Exception;
 use Carbon\Carbon;
+use Spatie\Backup\Helpers\Format;
 use Spatie\DbDumper\DbDumper;
 use Illuminate\Support\Collection;
 use Spatie\Backup\Events\BackupHasFailed;
@@ -202,9 +203,47 @@ class BackupJob
 
             $dbDumper->dumpToFile($temporaryFilePath);
 
+            if(config('laravel-backup.backup.gzipSql') === true) {
+                return $this->gzipSqlFile($dbDumper, $temporaryFilePath);
+            }
+
             return $temporaryFilePath;
+
         })->toArray();
     }
+
+    /**
+     * @param $temporaryFilePath
+     * @return string
+     */
+    protected function gzipSqlFile($dbDumper, $temporaryFilePath)
+    {
+        consoleOutput()->info("Gzipping {$dbDumper->getDbName()}...");
+
+        $gzipPath = $temporaryFilePath . '.gz';
+
+        if ($gzipOut = gzopen($gzipPath, 'w9')) {
+            if ($gzipIn = fopen($temporaryFilePath, 'rb')) {
+                while (!feof($gzipIn))
+                    gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
+                fclose($gzipIn);
+            }else{
+                consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
+                return $temporaryFilePath;
+            }
+
+            gzclose($gzipOut);
+        }else{
+            consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
+            return $temporaryFilePath;
+        }
+
+        consoleOutput()->info("Gzipped {$dbDumper->getDbName()} from ".Format::humanReadableSize(filesize($temporaryFilePath))." to ".Format::humanReadableSize(filesize($gzipPath)));
+
+        return $gzipPath;
+    }
+
+
 
     protected function copyToBackupDestinations(string $path)
     {

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -203,12 +203,11 @@ class BackupJob
 
             $dbDumper->dumpToFile($temporaryFilePath);
 
-            if(config('laravel-backup.backup.gzipSql') === true) {
+            if (config('laravel-backup.backup.gzipSql') === true) {
                 return $this->gzipSqlFile($dbDumper, $temporaryFilePath);
             }
 
             return $temporaryFilePath;
-
         })->toArray();
     }
 
@@ -224,16 +223,17 @@ class BackupJob
 
         if ($gzipOut = gzopen($gzipPath, 'w9')) {
             if ($gzipIn = fopen($temporaryFilePath, 'rb')) {
-                while (!feof($gzipIn))
+                while (!feof($gzipIn)) {
                     gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
+                }
                 fclose($gzipIn);
-            }else{
+            } else {
                 consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
                 return $temporaryFilePath;
             }
 
             gzclose($gzipOut);
-        }else{
+        } else {
             consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
             return $temporaryFilePath;
         }

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -211,7 +211,7 @@ class BackupJob
                 if ($gzipFile->failed) {
                     consoleOutput()->error("Gzip failed for {$dbDumper->getDbName()}");
                 } else {
-                    consoleOutput()->info("Gzipped {$dbDumper->getDbName()} from ".Format::humanReadableSize($gzipFile->oldFileSize())." to ".Format::humanReadableSize($gzipFile->newFileSize()));
+                    consoleOutput()->info("Gzipped {$dbDumper->getDbName()} from ".Format::humanReadableSize($gzipFile->oldFileSize()).' to '.Format::humanReadableSize($gzipFile->newFileSize()));
 
                     return $gzipFile->filePath;
                 }

--- a/src/Tasks/Backup/Gzip.php
+++ b/src/Tasks/Backup/Gzip.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Spatie\Backup\Tasks\Backup;
 
 class Gzip
 {
-
     /** @var string */
     public $originalFilePath;
 

--- a/src/Tasks/Backup/Gzip.php
+++ b/src/Tasks/Backup/Gzip.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Spatie\Backup\Tasks\Backup;
+
+class Gzip
+{
+
+    /** @var string */
+    public $originalFilePath;
+
+    /** @var string */
+    public $filePath;
+
+    /** @var bool */
+    public $failed;
+
+    public function __construct(string $filePath)
+    {
+        $this->originalFilePath = $filePath;
+
+        $this->filePath = $this->compress();
+
+        $this->failed = $this->originalFilePath == $this->filePath;
+    }
+
+    /**
+     * @return string
+     */
+    protected function compress()
+    {
+        $gzipPath = $this->originalFilePath.'.gz';
+
+        if ($gzipOut = gzopen($gzipPath, 'w9')) {
+            if ($gzipIn = fopen($this->originalFilePath, 'rb')) {
+                while (! feof($gzipIn)) {
+                    gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
+                }
+                fclose($gzipIn);
+            } else {
+                return $this->originalFilePath;
+            }
+
+            gzclose($gzipOut);
+        } else {
+            return $this->originalFilePath;
+        }
+
+        return $gzipPath;
+    }
+
+    /**
+     * @return int
+     */
+    public function oldFileSize()
+    {
+        return filesize($this->originalFilePath);
+    }
+
+    /**
+     * @return int
+     */
+    public function newFileSize()
+    {
+        return filesize($this->filePath);
+    }
+}

--- a/src/Tasks/Backup/Gzip.php
+++ b/src/Tasks/Backup/Gzip.php
@@ -29,18 +29,29 @@ class Gzip
     {
         $gzipPath = $this->originalFilePath.'.gz';
 
-        if ($gzipOut = gzopen($gzipPath, 'w9')) {
-            if ($gzipIn = fopen($this->originalFilePath, 'rb')) {
-                while (! feof($gzipIn)) {
-                    gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
-                }
-                fclose($gzipIn);
-            } else {
-                return $this->originalFilePath;
+        $gzipOut = false;
+        $gzipIn = false;
+
+        try {
+            $gzipOut = gzopen($gzipPath, 'w9');
+            $gzipIn = fopen($this->originalFilePath, 'rb');
+
+            while (!feof($gzipIn)) {
+                gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
             }
 
+            fclose($gzipIn);
             gzclose($gzipOut);
-        } else {
+        } catch (\Exception $exception) {
+            if (is_resource($gzipOut)) {
+                gzclose($gzipOut);
+                unlink($gzipPath);
+            }
+
+            if (is_resource($gzipIn)) {
+                fclose($gzipIn);
+            }
+
             return $this->originalFilePath;
         }
 

--- a/src/Tasks/Backup/Gzip.php
+++ b/src/Tasks/Backup/Gzip.php
@@ -36,7 +36,7 @@ class Gzip
             $gzipOut = gzopen($gzipPath, 'w9');
             $gzipIn = fopen($this->originalFilePath, 'rb');
 
-            while (!feof($gzipIn)) {
+            while (! feof($gzipIn)) {
                 gzwrite($gzipOut, fread($gzipIn, 1024 * 512));
             }
 

--- a/tests/Unit/GzipTest.php
+++ b/tests/Unit/GzipTest.php
@@ -17,4 +17,12 @@ class GzipTest extends \PHPUnit_Framework_TestCase
 
         unlink($gzip->filePath);
     }
+
+    /** @test */
+    public function it_fails_when_the_file_doesnt_exist()
+    {
+        $gzip = new Gzip('nonexistent.txt');
+
+        $this->assertTrue($gzip->failed);
+    }
 }

--- a/tests/Unit/GzipTest.php
+++ b/tests/Unit/GzipTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Backup\Test\Unit;
+
+use Spatie\Backup\Tasks\Backup\Gzip;
+use Spatie\Backup\Test\TestHelper;
+use Spatie\Backup\Tasks\Backup\Zip;
+
+class GzipTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_gzip_a_test_file()
+    {
+        $gzip = new Gzip((new TestHelper())->getStubDirectory()."/file1.txt");
+
+        // check for gzip identifier
+        $this->assertSame(0, mb_strpos(file_get_contents($gzip->filePath), "\x1f" . "\x8b" . "\x08"));
+
+        unlink($gzip->filePath);
+    }
+}

--- a/tests/Unit/GzipTest.php
+++ b/tests/Unit/GzipTest.php
@@ -2,19 +2,18 @@
 
 namespace Spatie\Backup\Test\Unit;
 
-use Spatie\Backup\Tasks\Backup\Gzip;
 use Spatie\Backup\Test\TestHelper;
-use Spatie\Backup\Tasks\Backup\Zip;
+use Spatie\Backup\Tasks\Backup\Gzip;
 
 class GzipTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
     public function it_can_gzip_a_test_file()
     {
-        $gzip = new Gzip((new TestHelper())->getStubDirectory()."/file1.txt");
+        $gzip = new Gzip((new TestHelper())->getStubDirectory().'/file1.txt');
 
         // check for gzip identifier
-        $this->assertSame(0, mb_strpos(file_get_contents($gzip->filePath), "\x1f" . "\x8b" . "\x08"));
+        $this->assertSame(0, mb_strpos(file_get_contents($gzip->filePath), "\x1f"."\x8b"."\x08"));
 
         unlink($gzip->filePath);
     }


### PR DESCRIPTION
According to issue #372, add an option to gzip the SQL files before zipping them. Very useful in my use case since .sql.gz files are a lot smaller while still able to be loaded into my SQL client, unlike .zip files.