### PR TITLE
Updated database dump file name generation to prevent overwrite.

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -6,6 +6,7 @@ use Exception;
 use Carbon\Carbon;
 use Spatie\DbDumper\DbDumper;
 use Illuminate\Support\Collection;
+use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\Backup\Events\BackupHasFailed;
 use Spatie\Backup\Events\BackupWasSuccessful;
 use Spatie\Backup\Events\BackupZipWasCreated;
@@ -196,7 +197,11 @@ class BackupJob
         return $this->dbDumpers->map(function (DbDumper $dbDumper) {
             consoleOutput()->info("Dumping database {$dbDumper->getDbName()}...");
 
-            $fileName = $dbDumper->getDbName().'.sql';
+            $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
+
+            $dbName = $dbDumper instanceof Sqlite ? 'database' : $dbDumper->getDbName();
+
+            $fileName = "{$dbType}-{$dbName}.sql";
 
             $temporaryFilePath = $this->temporaryDirectory->path('db-dumps'.DIRECTORY_SEPARATOR.$fileName);
 

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -72,14 +72,12 @@ abstract class TestCase extends Orchestra
      */
     protected function setUpDatabase($app)
     {
-        file_put_contents($this->testHelper->getTempDirectory().'/database.sqlite', null);
+        touch($this->testHelper->getTempDirectory().'/database.sqlite');
 
         $app['db']->connection()->getSchemaBuilder()->create('test_models', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
         });
-
-        TestModel::create(['name' => 'test']);
     }
 
     public function assertFileExistsOnDisk(string $fileName, string $diskName)


### PR DESCRIPTION
This fixes #439

Appends the database type to the file name to prevent multiple databases with the same name from being overwritten during backup.