### PR TITLE
Corrects link to the postcard page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You're free to use this package (it's [MIT-licensed](LICENSE.md)), but if it mak
 
 Our address is: Spatie, Samberstraat 69D, 2060 Antwerp, Belgium.
 
-All postcards are published [on our website](https://spatie.be/en/opensource/laravel).
+All postcards are published [on our website](https://spatie.be/en/opensource/postcards).
 
 ## Installation and usage
 


### PR DESCRIPTION
The current link is to the list of laravel packages