### PR TITLE
Fix test failure

### DIFF
--- a/tests/Unit/FileSelectionTest.php
+++ b/tests/Unit/FileSelectionTest.php
@@ -22,8 +22,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
     {
         $fileSelection = new FileSelection($this->sourceDirectory);
 
-        $this->assertSame(
-            $this->getTestFiles([
+        $testFiles = $this->getTestFiles([
                 '.dotfile',
                 '1Mb.file',
                 'directory1/directory1/file1.txt',
@@ -34,9 +33,13 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file1.txt',
                 'file2.txt',
                 'file3.txt',
-            ]),
-            iterator_to_array($fileSelection->selectedFiles())
-        );
+            ]);
+        $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
+
+        sort($testFiles);
+        sort($selectedFiles);
+
+        $this->assertSame($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -45,17 +48,20 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
         $fileSelection = (new FileSelection($this->sourceDirectory))
                         ->excludeFilesFrom("{$this->sourceDirectory}/directory1");
 
-        $this->assertSame(
-            $this->getTestFiles([
+        $testFiles = $this->getTestFiles([
                 '.dotfile',
                 '1Mb.file',
                 'directory2/directory1/file1.txt',
                 'file1.txt',
                 'file2.txt',
                 'file3.txt',
-            ]),
-            iterator_to_array($fileSelection->selectedFiles())
-        );
+            ]);
+        $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
+
+        sort($testFiles);
+        sort($selectedFiles);
+
+        $this->assertSame($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -64,8 +70,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
         $fileSelection = (new FileSelection($this->sourceDirectory))
             ->excludeFilesFrom("{$this->sourceDirectory}/*/directory1");
 
-        $this->assertSame(
-            $this->getTestFiles([
+        $testFiles = $this->getTestFiles([
                 '.dotfile',
                 '1Mb.file',
                 'directory1/file1.txt',
@@ -73,9 +78,13 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file1.txt',
                 'file2.txt',
                 'file3.txt',
-            ]),
-            iterator_to_array($fileSelection->selectedFiles())
-        );
+            ]);
+        $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
+
+        sort($testFiles);
+        sort($selectedFiles);
+
+        $this->assertSame($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -105,17 +114,20 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
                 'file2.txt',
             ]));
 
-        $this->assertSame(
-            $this->getTestFiles([
+        $testFiles = $this->getTestFiles([
                 '.dotfile',
                 '1Mb.file',
                 'directory1/file1.txt',
                 'directory1/file2.txt',
                 'file1.txt',
                 'file3.txt',
-            ]),
-            iterator_to_array($fileSelection->selectedFiles())
-        );
+            ]);
+        $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
+
+        sort($testFiles);
+        sort($selectedFiles);
+
+        $this->assertSame($testFiles, $selectedFiles);
     }
 
     /** @test */

--- a/tests/Unit/FileSelectionTest.php
+++ b/tests/Unit/FileSelectionTest.php
@@ -36,10 +36,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
             ]);
         $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
 
-        sort($testFiles);
-        sort($selectedFiles);
-
-        $this->assertSame($testFiles, $selectedFiles);
+        $this->assertSameArray($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -58,10 +55,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
             ]);
         $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
 
-        sort($testFiles);
-        sort($selectedFiles);
-
-        $this->assertSame($testFiles, $selectedFiles);
+        $this->assertSameArray($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -81,10 +75,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
             ]);
         $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
 
-        sort($testFiles);
-        sort($selectedFiles);
-
-        $this->assertSame($testFiles, $selectedFiles);
+        $this->assertSameArray($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -124,10 +115,7 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
             ]);
         $selectedFiles = iterator_to_array($fileSelection->selectedFiles());
 
-        sort($testFiles);
-        sort($selectedFiles);
-
-        $this->assertSame($testFiles, $selectedFiles);
+        $this->assertSameArray($testFiles, $selectedFiles);
     }
 
     /** @test */
@@ -177,5 +165,12 @@ class FileSelectionTest extends \PHPUnit_Framework_TestCase
         }, $relativePaths);
 
         return $absolutePaths;
+    }
+
+    protected function assertSameArray(array $array1, array $array2)
+    {
+        sort($array1);
+        sort($array2);
+        $this->assertSame($array1, $array2);
     }
 }


### PR DESCRIPTION
Selection of files ($fileSelection->selectedFiles())  seems that in some environments generates an unordered array giving a false positive #500 . Sort the arrays before compare it fixes the problem.