### PR TITLE
Empty the Temp directory before starting a backup job

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -118,7 +118,8 @@ class BackupJob
         $this->temporaryDirectory = (new TemporaryDirectory(storage_path('app/laravel-backup')))
             ->name('temp')
             ->force()
-            ->create();
+            ->create()
+            ->empty();
 
         try {
             if (! count($this->backupDestinations)) {

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -261,6 +261,26 @@ class BackupCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_should_start_with_a_clean_temp_directory()
+    {
+        // start with a file in the backup temp directory
+        $tempDirectoryPath = storage_path('app/laravel-backup/temp');
+        if (! file_exists($tempDirectoryPath)) {
+            mkdir($tempDirectoryPath, 0777, true);
+        }
+        touch($tempDirectoryPath.DIRECTORY_SEPARATOR.'testing-file.txt');
+
+        // we expect the backup to fail
+        $this->expectsEvent(BackupHasFailed::class);
+        $this->app['config']->set('laravel-backup.backup.source.files.include', []);
+        $this->app['config']->set('laravel-backup.backup.source.databases', []);
+        Artisan::call('backup:run');
+
+        // make sure the file we added to temp is now gone
+        $this->assertFalse(realpath($tempDirectoryPath.DIRECTORY_SEPARATOR.'testing-file.txt'));
+    }
+
+    /** @test */
     public function it_should_trigger_the_backup_failed_event()
     {
         $this->expectsEvent(BackupHasFailed::class);


### PR DESCRIPTION
There is an edge case where the temp file fills up until it is using all available space, causing future backups to fail. Since a failed backup does not clean the temp directory, the backup process will never succeed without intervention.

This is solved by always clearing the temp file before starting the backup job.