### PR TITLE
[WIP] Makes backups to be created at exact specified location locally and fixes #185

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -8,7 +8,7 @@ return [
          * The name of this application. You can use this name to monitor
          * the backups.
          */
-        'name' => env('APP_URL'),
+        'name' => env('APP_NAME'),
 
         'source' => [
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
         </whitelist>
     </filter>
     <php>
+        <env name="APP_NAME" value="mysite"/>
         <env name="APP_URL" value="mysite.com"/>
     </php>
 </phpunit>

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -78,7 +78,7 @@ class BackupDestination
             throw InvalidBackupDestination::diskNotSet();
         }
 
-        $destination = $this->backupName.'/'.pathinfo($file, PATHINFO_BASENAME);
+        $destination = pathinfo($file, PATHINFO_BASENAME);
 
         $handle = fopen($file, 'r+');
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -2,18 +2,18 @@
 
 namespace Spatie\Backup\Tasks\Backup;
 
-use Carbon\Carbon;
 use Exception;
+use Carbon\Carbon;
+use Spatie\DbDumper\DbDumper;
 use Illuminate\Support\Collection;
-use Spatie\Backup\BackupDestination\BackupDestination;
+use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\Backup\Events\BackupHasFailed;
-use Spatie\Backup\Events\BackupManifestWasCreated;
 use Spatie\Backup\Events\BackupWasSuccessful;
 use Spatie\Backup\Events\BackupZipWasCreated;
 use Spatie\Backup\Exceptions\InvalidBackupJob;
-use Spatie\DbDumper\Databases\Sqlite;
-use Spatie\DbDumper\DbDumper;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Spatie\Backup\Events\BackupManifestWasCreated;
+use Spatie\Backup\BackupDestination\BackupDestination;
 
 class BackupJob
 {

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -117,7 +117,7 @@ class BackupJob
     {
         $disk = config('backup.backup.destination.disks');
 
-        return config("filesystems.disks.$disk[0].root");
+        return config("filesystems.disks.$disk[0].root") ?? storage_path('app/backups');
     }
 
     public function run()

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -115,7 +115,9 @@ class BackupJob
 
     public function temporaryDirectoryLocation(): string
     {
-        return config('filesystems.disks.backups.root');
+        $disk = config('backup.backup.destination.disks');
+
+        return config("filesystems.disks.$disk[0].root");
     }
 
     public function run()


### PR DESCRIPTION
- Resolves #185 
- The `temp` directory is now created in the specified backup folder itself and removes creation of an empty `backup` folder in `/storage/app` directory.
- `APP_NAME` is used instead of `APP_URL` for the name property which I think would be more appropriate.
- Removed unused imports.

Open to suggestions and feedback :)