### PR TITLE
fix CleanupHasFailed application_name translation not working

### DIFF
--- a/src/Notifications/Notifications/CleanupHasFailed.php
+++ b/src/Notifications/Notifications/CleanupHasFailed.php
@@ -17,8 +17,8 @@ class CleanupHasFailed extends BaseNotification
     {
         $mailMessage = (new MailMessage)
             ->error()
-            ->subject(trans('backup::notifications.cleanup_failed_subject', ['application_name', $this->applicationName()]))
-            ->line(trans('backup::notifications.cleanup_failed_body', ['application_name', $this->applicationName()]))
+            ->subject(trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
+            ->line(trans('backup::notifications.cleanup_failed_body', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))
             ->line(trans('backup::notifications.exception_trace', ['trace' => $this->event->exception->getTraceAsString()]));
 
@@ -34,7 +34,7 @@ class CleanupHasFailed extends BaseNotification
         return (new SlackMessage)
             ->error()
             ->to(config('backup.notifications.slack.channel'))
-            ->content(trans('backup::notifications.cleanup_failed_subject', ['application_name', $this->applicationName()]))
+            ->content(trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
                     ->title(trans('backup::notifications.exception_message_title'))


### PR DESCRIPTION
fix the :application_name not getting translated for failed backup cleanup notifications