### PR TITLE
Fix deleting all backups when using maximum storage

### DIFF
--- a/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
+++ b/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
@@ -115,6 +115,8 @@ class DefaultStrategy extends CleanupStrategy
 
         $oldest->delete();
 
+        $backups = $backups->filter->exists();
+
         $this->removeOldBackupsUntilUsingLessThanMaximumStorage($backups);
     }
 }

--- a/tests/Integration/CleanupCommandTest.php
+++ b/tests/Integration/CleanupCommandTest.php
@@ -27,7 +27,6 @@ class CleanupCommandTest extends TestCase
     /** @test */
     public function it_can_remove_old_backups_until_using_less_than_maximum_storage()
     {
-        // 1 megabyte storage size
         $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 2);
 
         $this->testHelper->createTempFile1Mb('mysite/test1.zip', Carbon::now()->subDays(1));

--- a/tests/Integration/CleanupCommandTest.php
+++ b/tests/Integration/CleanupCommandTest.php
@@ -28,15 +28,23 @@ class CleanupCommandTest extends TestCase
     public function it_can_remove_old_backups_until_using_less_than_maximum_storage()
     {
         // 1 megabyte storage size
-        $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 1);
+        $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 2);
 
         $this->testHelper->createTempFile1Mb('mysite.com/test1.zip', Carbon::now()->subDays(1));
         $this->testHelper->createTempFile1Mb('mysite.com/test2.zip', Carbon::now()->subDays(2));
+        $this->testHelper->createTempFile1Mb('mysite.com/test3.zip', Carbon::now()->subDays(3));
+        $this->testHelper->createTempFile1Mb('mysite.com/test4.zip', Carbon::now()->subDays(4));
 
         Artisan::call('backup:clean');
 
         $this->assertTempFilesExist([
             'mysite.com/test1.zip',
+            'mysite.com/test2.zip',
+        ]);
+
+        $this->assertTempFilesNotExist([
+            'mysite.com/test3.zip',
+            'mysite.com/test4.zip',
         ]);
     }
 

--- a/tests/Integration/CleanupCommandTest.php
+++ b/tests/Integration/CleanupCommandTest.php
@@ -30,21 +30,21 @@ class CleanupCommandTest extends TestCase
         // 1 megabyte storage size
         $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 2);
 
-        $this->testHelper->createTempFile1Mb('mysite.com/test1.zip', Carbon::now()->subDays(1));
-        $this->testHelper->createTempFile1Mb('mysite.com/test2.zip', Carbon::now()->subDays(2));
-        $this->testHelper->createTempFile1Mb('mysite.com/test3.zip', Carbon::now()->subDays(3));
-        $this->testHelper->createTempFile1Mb('mysite.com/test4.zip', Carbon::now()->subDays(4));
+        $this->testHelper->createTempFile1Mb('mysite/test1.zip', Carbon::now()->subDays(1));
+        $this->testHelper->createTempFile1Mb('mysite/test2.zip', Carbon::now()->subDays(2));
+        $this->testHelper->createTempFile1Mb('mysite/test3.zip', Carbon::now()->subDays(3));
+        $this->testHelper->createTempFile1Mb('mysite/test4.zip', Carbon::now()->subDays(4));
 
         Artisan::call('backup:clean');
 
         $this->assertTempFilesExist([
-            'mysite.com/test1.zip',
-            'mysite.com/test2.zip',
+            'mysite/test1.zip',
+            'mysite/test2.zip',
         ]);
 
         $this->assertTempFilesNotExist([
-            'mysite.com/test3.zip',
-            'mysite.com/test4.zip',
+            'mysite/test3.zip',
+            'mysite/test4.zip',
         ]);
     }
 
@@ -130,18 +130,18 @@ class CleanupCommandTest extends TestCase
     /** @test */
     public function it_will_leave_non_zip_files_alone()
     {
-        $this->testHelper->createTempFileWithAge('mysite.com/test1.txt', Carbon::now()->subDays(1));
-        $this->testHelper->createTempFileWithAge('mysite.com/test2.txt', Carbon::now()->subDays(2));
-        $this->testHelper->createTempFileWithAge('mysite.com/test1000.txt', Carbon::now()->subDays(1000));
-        $this->testHelper->createTempFileWithAge('mysite.com/test2000.txt', Carbon::now()->subDays(2000));
+        $this->testHelper->createTempFileWithAge('mysite/test1.txt', Carbon::now()->subDays(1));
+        $this->testHelper->createTempFileWithAge('mysite/test2.txt', Carbon::now()->subDays(2));
+        $this->testHelper->createTempFileWithAge('mysite/test1000.txt', Carbon::now()->subDays(1000));
+        $this->testHelper->createTempFileWithAge('mysite/test2000.txt', Carbon::now()->subDays(2000));
 
         Artisan::call('backup:clean');
 
         $this->assertTempFilesExist([
-            'mysite.com/test1.txt',
-            'mysite.com/test2.txt',
-            'mysite.com/test1000.txt',
-            'mysite.com/test2000.txt',
+            'mysite/test1.txt',
+            'mysite/test2.txt',
+            'mysite/test1000.txt',
+            'mysite/test2000.txt',
         ]);
     }
 
@@ -172,18 +172,18 @@ class CleanupCommandTest extends TestCase
     {
         $this->expectsEvents(CleanupWasSuccessful::class);
 
-        $this->testHelper->createTempFileWithAge('mysite.com/test1.txt', Carbon::now()->subDays(1));
-        $this->testHelper->createTempFileWithAge('mysite.com/test2.txt', Carbon::now()->subDays(2));
-        $this->testHelper->createTempFileWithAge('mysite.com/test1000.txt', Carbon::now()->subDays(1000));
-        $this->testHelper->createTempFileWithAge('mysite.com/test2000.txt', Carbon::now()->subDays(2000));
+        $this->testHelper->createTempFileWithAge('mysite/test1.txt', Carbon::now()->subDays(1));
+        $this->testHelper->createTempFileWithAge('mysite/test2.txt', Carbon::now()->subDays(2));
+        $this->testHelper->createTempFileWithAge('mysite/test1000.txt', Carbon::now()->subDays(1000));
+        $this->testHelper->createTempFileWithAge('mysite/test2000.txt', Carbon::now()->subDays(2000));
 
         Artisan::call('backup:clean');
 
         $this->assertTempFilesExist([
-            'mysite.com/test1.txt',
-            'mysite.com/test2.txt',
-            'mysite.com/test1000.txt',
-            'mysite.com/test2000.txt',
+            'mysite/test1.txt',
+            'mysite/test2.txt',
+            'mysite/test1000.txt',
+            'mysite/test2000.txt',
         ]);
     }
 
@@ -192,18 +192,18 @@ class CleanupCommandTest extends TestCase
     {
         $this->doesntExpectEvents(CleanupWasSuccessful::class);
 
-        $this->testHelper->createTempFileWithAge('mysite.com/test1.txt', Carbon::now()->subDays(1));
-        $this->testHelper->createTempFileWithAge('mysite.com/test2.txt', Carbon::now()->subDays(2));
-        $this->testHelper->createTempFileWithAge('mysite.com/test1000.txt', Carbon::now()->subDays(1000));
-        $this->testHelper->createTempFileWithAge('mysite.com/test2000.txt', Carbon::now()->subDays(2000));
+        $this->testHelper->createTempFileWithAge('mysite/test1.txt', Carbon::now()->subDays(1));
+        $this->testHelper->createTempFileWithAge('mysite/test2.txt', Carbon::now()->subDays(2));
+        $this->testHelper->createTempFileWithAge('mysite/test1000.txt', Carbon::now()->subDays(1000));
+        $this->testHelper->createTempFileWithAge('mysite/test2000.txt', Carbon::now()->subDays(2000));
 
         Artisan::call('backup:clean', ['--disable-notifications' => true]);
 
         $this->assertTempFilesExist([
-            'mysite.com/test1.txt',
-            'mysite.com/test2.txt',
-            'mysite.com/test1000.txt',
-            'mysite.com/test2000.txt',
+            'mysite/test1.txt',
+            'mysite/test2.txt',
+            'mysite/test1000.txt',
+            'mysite/test2000.txt',
         ]);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in `DefaultStrategy` where all backups would be removed when cleaning old backups due to maximum storage being reached (see #505).

This PR also fixes the `it_can_remove_old_backups_until_using_less_than_maximum_storage` test to catch the issue if it were to happen again.

Finally the testing `APP_NAME` environment variable is set to `mysite` in `phpunit.xml.dist` however in a lot of the tests `mysite.com` was used. I've made all the tests use the same `APP_NAME` now for consistency.

Fixes #505