### PR TITLE
Feature disable backups per environment

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -5,6 +5,11 @@ return [
     'backup' => [
 
         /*
+         * Flag to determine if the backup should be run on the current env
+         */
+        'run' => env('BACKUP', true),
+
+        /*
          * The name of this application. You can use this name to monitor
          * the backups.
          */

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -4,6 +4,7 @@ namespace Spatie\Backup\Commands;
 
 use Illuminate\Console\Command;
 use Spatie\Backup\Helpers\ConsoleOutput;
+use Spatie\Backup\Exceptions\BackupsDisabled;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -17,6 +18,10 @@ abstract class BaseCommand extends Command
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
+        if (! config('backup.backup.run', true)) {
+            throw BackupsDisabled::disabled();
+        }
+
         app(ConsoleOutput::class)->setOutput($this);
 
         return parent::run($input, $output);

--- a/src/Exceptions/BackupsDisabled.php
+++ b/src/Exceptions/BackupsDisabled.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Backup\Exceptions;
+
+use Exception;
+
+class BackupsDisabled extends Exception
+{
+    public static function disabled(): BackupsDisabled
+    {
+        return new static('Backups are disabled for this environment');
+    }
+}

--- a/tests/Integration/DisableBackupsTest.php
+++ b/tests/Integration/DisableBackupsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\Backup\Test\Integration;
+
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Backup\Exceptions\BackupsDisabled;
+
+class DisableBackupsTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->app['config']->set('backup.backup.run', false);
+    }
+
+    /** @test */
+    public function it_can_disable_backups()
+    {
+        $this->expectException(BackupsDisabled::class);
+
+        Artisan::call('backup:list');
+    }
+}


### PR DESCRIPTION
I have an application installed on several environments and some needs backup and some other no, so I need to have a way to disable it by configuration.

This PR adds the ability to disable the backups depending on a config. By default all backups will be enabled, just need to add `BACKUP=false` to the _.env_ file.