### PR TITLE
Use correct exit codes

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -56,11 +56,11 @@ class BackupCommand extends BaseCommand
                 event(new BackupHasFailed($exception));
             }
 
-            return -1;
+            return 1;
         }
     }
 
-    protected function guardAgainstInvalidOptions()
+    protected function guardAgainstInvalidOptions(): void
     {
         if ($this->option('only-db') && $this->option('only-files')) {
             throw InvalidCommand::create('Cannot use `only-db` and `only-files` together');

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -60,7 +60,7 @@ class BackupCommand extends BaseCommand
         }
     }
 
-    protected function guardAgainstInvalidOptions(): void
+    protected function guardAgainstInvalidOptions()
     {
         if ($this->option('only-db') && $this->option('only-files')) {
             throw InvalidCommand::create('Cannot use `only-db` and `only-files` together');

--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -38,7 +38,7 @@ class CleanupCommand extends BaseCommand
                 event(new CleanupHasFailed($exception));
             }
 
-            return -1;
+            return 1;
         }
     }
 }


### PR DESCRIPTION
I'm using this package as part of a deployment hook on Envoyer so that I can backup my site every time I deploy.

Currently, if a backup fails, the deployment script carries on because the `backup:run` command returns an exit code of `-1`.

I've updated it in this PR so that it return `1` instead which signals a general error and will fail the deployment if a backup cannot be taken successfully.