### PR TITLE
Rethrow exceptions to exit properly on error

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -139,6 +139,10 @@ class BackupJob
             consoleOutput()->error("Backup failed because {$exception->getMessage()}.".PHP_EOL.$exception->getTraceAsString());
 
             $this->sendNotification(new BackupHasFailed($exception));
+
+            $this->temporaryDirectory->delete();
+
+            throw $exception;
         }
 
         $this->temporaryDirectory->delete();

--- a/src/Tasks/Cleanup/CleanupJob.php
+++ b/src/Tasks/Cleanup/CleanupJob.php
@@ -48,6 +48,8 @@ class CleanupJob
                 consoleOutput()->error("Cleanup failed because: {$exception->getMessage()}.");
 
                 $this->sendNotification(new CleanupHasFailed($exception));
+
+                throw $exception;
             }
         });
     }

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -189,7 +189,7 @@ class BackupCommandTest extends TestCase
             '--only-db'    => true,
         ]);
 
-        $this->assertEquals(-1, $resultCode);
+        $this->assertEquals(1, $resultCode);
 
         $this->seeInConsoleOutput('Cannot use `only-db` and `only-files` together.');
 
@@ -215,7 +215,7 @@ class BackupCommandTest extends TestCase
             '--only-to-disk' => 'non existing disk',
         ]);
 
-        $this->assertEquals(-1, $resultCode);
+        $this->assertEquals(1, $resultCode);
 
         $this->seeInConsoleOutput('There is not backup destination with a disk named');
 


### PR DESCRIPTION
This PR contains a couple of things:

## Rethrowing Exceptions
If a Backup or Cleanup task fails, it will re-throw the caught exception, to allow the calling Command to catch the exception again and act accordingly (in this case, returning the correct exit code).

This shouldn't cause any regressions - I've been careful to delete the temporary directory before re-throwing the exception in the `BackupJob` class. The notifications should also still get sent, and the console output should remain the same.

The `run()` methods of both the `BackupJob` and `CleanupJob` are only called in the Commands, and both of these have extra `try..catch` blocks around them to catch the re-thrown exception.

## Fix Failing Tests
I've also fixed the two failing tests that weren't updated in #606. Sorry... That was my mistake 😄 