### PR TITLE
Add ability to specify database connections to be backed up

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -10,7 +10,7 @@ use Spatie\Backup\Tasks\Backup\BackupJobFactory;
 class BackupCommand extends BaseCommand
 {
     /** @var string */
-    protected $signature = 'backup:run {--filename=} {--only-db} {--only-files} {--only-to-disk=} {--disable-notifications}';
+    protected $signature = 'backup:run {--filename=} {--only-db} {--connection=*} {--only-files} {--only-to-disk=} {--disable-notifications}';
 
     /** @var string */
     protected $description = 'Run the backup.';
@@ -28,6 +28,10 @@ class BackupCommand extends BaseCommand
 
             if ($this->option('only-db')) {
                 $backupJob->dontBackupFilesystem();
+            }
+
+            if ($this->option('connection')) {
+                $backupJob->setDbDumpers(BackupJobFactory::createDbDumpers($this->option('connection')));
             }
 
             if ($this->option('only-files')) {

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -214,7 +214,12 @@ class BackupJob
 
             $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
 
-            $dbName = $dbDumper instanceof Sqlite ? 'database' : $dbDumper->getDbName();
+            $dbName = $dbDumper->getDbName();
+
+            if ($dbDumper instanceof Sqlite) {
+                // get the lowercased base file name without the extenstion
+                $dbName = mb_strtolower(basename($dbName, '.sqlite'));
+            }
 
             $fileName = "{$dbType}-{$dbName}.sql";
 

--- a/src/Tasks/Backup/BackupJobFactory.php
+++ b/src/Tasks/Backup/BackupJobFactory.php
@@ -22,7 +22,7 @@ class BackupJobFactory
             ->shouldFollowLinks(isset($sourceFiles['followLinks']) && $sourceFiles['followLinks']);
     }
 
-    protected static function createDbDumpers(array $dbConnectionNames): Collection
+    public static function createDbDumpers(array $dbConnectionNames): Collection
     {
         return collect($dbConnectionNames)->map(function (string $dbConnectionName) {
             return DbDumperFactory::createFromConnection($dbConnectionName);

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -307,4 +307,29 @@ class BackupCommandTest extends TestCase
          */
         $this->app['db']->disconnect();
     }
+
+    /** @test */
+    public function it_can_backup_only_a_specified_database_connection()
+    {
+        $resultCode = Artisan::call('backup:run', [
+            '--only-db' => true,
+            '--connection' => ['sqlite2'],
+        ]);
+
+        $this->assertEquals(0, $resultCode);
+
+        $backupDiskLocal = $this->app['config']->get('filesystems.disks.local.root');
+        $backupFileLocal = $backupDiskLocal . DIRECTORY_SEPARATOR . $this->expectedZipPath;
+        $this->assertFileDoesntExistsInZip($backupFileLocal, 'sqlite-database.sql');
+
+        $backupDiskLocal = $this->app['config']->get('filesystems.disks.local.root');
+        $backupFileLocal = $backupDiskLocal . DIRECTORY_SEPARATOR . $this->expectedZipPath;
+        $this->assertFileExistsInZip($backupFileLocal, 'sqlite-database2.sql');
+
+        /*
+         * Close the database connection to unlock the sqlite file for deletion.
+         * This prevents the errors from other tests trying to delete and recreate the folder.
+         */
+        $this->app['db']->disconnect();
+    }
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -50,6 +50,12 @@ abstract class TestCase extends Orchestra
             'prefix' => '',
         ]);
 
+        $app['config']->set('database.connections.sqlite2', [
+            'driver' => 'sqlite',
+            'database' => $this->testHelper->getTempDirectory().'/database2',
+            'prefix' => '',
+        ]);
+
         $app['config']->set('filesystems.disks.local', [
             'driver' => 'local',
             'root' => $this->testHelper->getTempDirectory(),

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -41,8 +41,6 @@ abstract class TestCase extends Orchestra
     {
         $this->testHelper->initializeTempDirectory();
 
-        $app['config']->set('database.default', 'sqlite');
-
         $app['config']->set('mail.driver', 'log');
 
         $app['config']->set('database.default', 'sqlite');


### PR DESCRIPTION
The `--connection` argument overrides the default configuration. Multiple connections can be specified with multiple `--connection` arguments.

Also adds ability to backup multiple sqlite databases by extracting the name of the sqlite database from the file path. 

Resolves #614 
Closes #615 