### PR TITLE
filter backup files by mime type when possible

### DIFF
--- a/src/BackupDestination/BackupCollection.php
+++ b/src/BackupDestination/BackupCollection.php
@@ -9,6 +9,11 @@ class BackupCollection extends Collection
     /** @var null|int */
     protected $sizeCache = null;
 
+    /** @var array */
+    protected static $allowedMimeTypes = [
+        'application/zip', 'application/x-zip', 'application/x-gzip'
+    ];
+
     /**
      * @param \Illuminate\Contracts\Filesystem\Filesystem|null $disk
      * @param array                                            $files
@@ -18,7 +23,11 @@ class BackupCollection extends Collection
     public static function createFromFiles($disk, array $files): self
     {
         return (new static($files))
-            ->filter(function ($path) {
+            ->filter(function ($path) use ($disk) {
+                if ($disk && method_exists($disk, 'mimeType')) {
+                    return in_array($disk->mimeType($path), self::$allowedMimeTypes);
+                }
+
                 return pathinfo($path, PATHINFO_EXTENSION) === 'zip';
             })
             ->map(function ($path) use ($disk) {

--- a/tests/Integration/BackupDestination/BackupCollectionTest.php
+++ b/tests/Integration/BackupDestination/BackupCollectionTest.php
@@ -101,9 +101,9 @@ class BackupCollectionTest extends TestCase
     /** @test */
     public function it_can_determine_the_size_of_the_backups()
     {
-        $this->createFileOnBackupDisk('file1.zip', 1, 'some content');
-        $this->createFileOnBackupDisk('file2.zip', 1, 'even more content');
-        $this->createFileOnBackupDisk('file3.zip', 1, 'you guessed it: content');
+        $this->createFileOnBackupDisk('file1.zip', 1, gzencode('some content'));
+        $this->createFileOnBackupDisk('file2.zip', 1, gzencode('even more content'));
+        $this->createFileOnBackupDisk('file3.zip', 1, gzencode('you guessed it: content'));
 
         $totalSize = filesize($this->testHelper->getTempDirectory().'/mysite.com/file1.zip')
             + filesize($this->testHelper->getTempDirectory().'/mysite.com/file2.zip')


### PR DESCRIPTION
Hey guys!

This pull request is in reference to [issue 612](https://github.com/spatie/laravel-backup/issues/612).

The `backup:monitor` and `backup:clean` commands were not working properly when using `nao-pon/flysystem-google-drive` filesystem.

The issue was due to the fact that the `BackupCollection` class filters files based on their extension, and the Google Drive file system `allFiles` method (used to create the backup collection) returns a list of files named by file ID, and therefore have no extension in their file name.

I thought it could be a good solution to use the `$disk` object that owns the files to check its mime type instead of the extension, when the `$disk` object has the `mimeType` method.

I had to change the `it_can_determine_the_size_of_the_backups` test to set the content of the file to a gzipped string instead, so the mime type would be application/x-gzip. I don't like the fact that I had to change the test to make this work...but it makes sense to me that the content of a zip file should be zipped...

This is my first pull request. I hope I did everything right...please play nice 😊