### PR TITLE
Added compatibility with mariaDB drivers

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -52,7 +52,7 @@ class DbDumperFactory
     {
         $driver = strtolower($dbDriver);
 
-        if ($driver === 'mysql') {
+        if ($driver === 'mysql' || $driver === 'mariadb') {
             return new MySql();
         }
 


### PR DESCRIPTION
Just to make it work with people using a package like https://github.com/ybr-nx/laravel-mariadb
We are required to change driver name and this leads to errors when trying to make a database backup.

```
'mysql' => [
            'driver' => 'mariadb',
```

It just works same, but with this library we able to query json for your other translatable package.

Thanks.