### PR TITLE
Check false mime types + tests

### DIFF
--- a/src/BackupDestination/BackupCollection.php
+++ b/src/BackupDestination/BackupCollection.php
@@ -9,11 +9,6 @@ class BackupCollection extends Collection
     /** @var null|int */
     protected $sizeCache = null;
 
-    /** @var array */
-    protected static $allowedMimeTypes = [
-        'application/zip', 'application/x-zip', 'application/x-gzip',
-    ];
-
     /**
      * @param \Illuminate\Contracts\Filesystem\Filesystem|null $disk
      * @param array                                            $files
@@ -24,11 +19,7 @@ class BackupCollection extends Collection
     {
         return (new static($files))
             ->filter(function ($path) use ($disk) {
-                if ($disk && method_exists($disk, 'mimeType')) {
-                    return in_array($disk->mimeType($path), self::$allowedMimeTypes);
-                }
-
-                return pathinfo($path, PATHINFO_EXTENSION) === 'zip';
+                return (new BackupPath)->isBackupFile($disk, $path);
             })
             ->map(function ($path) use ($disk) {
                 return new Backup($disk, $path);

--- a/src/BackupDestination/BackupPath.php
+++ b/src/BackupDestination/BackupPath.php
@@ -21,7 +21,7 @@ class BackupPath
      */
     public function isBackupFile($disk, string $path) : bool
     {
-        return $this->hasAllowedMimeType($disk, $path) ?: $this->hasZipExtension($path);
+        return $this->hasZipExtension($path) ?: $this->hasAllowedMimeType($disk, $path);
     }
 
     /**

--- a/src/BackupDestination/BackupPath.php
+++ b/src/BackupDestination/BackupPath.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Spatie\Backup\BackupDestination;
+
+use Exception;
+
+class BackupPath
+{
+    /** @var array */
+    protected static $allowedMimeTypes = [
+        'application/zip',
+        'application/x-zip',
+        'application/x-gzip',
+    ];
+
+    /**
+     * @param \Illuminate\Contracts\Filesystem\Filesystem|null $disk
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function isBackupFile($disk, string $path) : bool
+    {
+        return $this->hasAllowedMimeType($disk, $path) ?: $this->hasZipExtension($path);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    protected function hasZipExtension($path)
+    {
+        return pathinfo($path, PATHINFO_EXTENSION) === 'zip';
+    }
+
+    /**
+     * @param \Illuminate\Contracts\Filesystem\Filesystem|null $disk
+     * @param string $path
+     *
+     * @return bool
+     */
+    protected function hasAllowedMimeType($disk, $path)
+    {
+        return in_array($this->mimeType($disk, $path), self::$allowedMimeTypes);
+    }
+
+    /**
+     * @param \Illuminate\Contracts\Filesystem\Filesystem|null $disk
+     * @param string $path
+     *
+     * @return string|false
+     */
+    protected function mimeType($disk, $path)
+    {
+        try {
+            if ($disk && method_exists($disk, 'mimeType')) {
+                return $disk->mimeType($path) ?: false;
+            }
+        } catch (Exception $exception) {
+            // Some drivers throw exceptions when checking mime types, we'll
+            // just fallback to `false`.
+        }
+
+        return false;
+    }
+}

--- a/tests/Integration/BackupDestination/BackupCollectionTest.php
+++ b/tests/Integration/BackupDestination/BackupCollectionTest.php
@@ -120,18 +120,7 @@ class BackupCollectionTest extends TestCase
     }
 
     /** @test */
-    public function it_checks_mime_type_instead_of_extension()
-    {
-        $this->localFilesystemOnMimeTypeCheckToReturn(['mimetype' => 'application/zip']);
-        $this->createFileOnBackupDisk('file1');
-
-        $backups = $this->getBackupCollectionForCurrentDiskContents();
-
-        $this->assertCount(1, $backups);
-    }
-
-    /** @test */
-    public function it_skips_mime_type_check_if_mime_type_is_false()
+    public function it_checks_zip_extension_before_checking_mime_type()
     {
         $this->localFilesystemOnMimeTypeCheckToReturn(false);
         $this->createFileOnBackupDisk('file1.zip');
@@ -142,16 +131,38 @@ class BackupCollectionTest extends TestCase
     }
 
     /** @test */
-    public function it_skips_mime_type_check_if_getting_mime_type_throws_exception()
+    public function it_checks_mime_type_when_no_zip_extension_present()
     {
-        $this->localFilesystemOnMimeTypeCheckToReturn(function () {
-            throw new Exception('No mime type specified');
-        });
-        $this->createFileOnBackupDisk('file1.zip');
+        $this->localFilesystemOnMimeTypeCheckToReturn(['mimetype' => 'application/zip']);
+        $this->createFileOnBackupDisk('file1');
 
         $backups = $this->getBackupCollectionForCurrentDiskContents();
 
         $this->assertCount(1, $backups);
+    }
+
+    /** @test */
+    public function it_skips_file_if_filesystem_mime_type_check_returns_false()
+    {
+        $this->localFilesystemOnMimeTypeCheckToReturn(false);
+        $this->createFileOnBackupDisk('file1');
+
+        $backups = $this->getBackupCollectionForCurrentDiskContents();
+
+        $this->assertCount(0, $backups);
+    }
+
+    /** @test */
+    public function it_skips_file_if_exceptions_throw_by_filesystem_mime_type_check()
+    {
+        $this->localFilesystemOnMimeTypeCheckToReturn(function () {
+            throw new Exception('No mime type specified');
+        });
+        $this->createFileOnBackupDisk('file1');
+
+        $backups = $this->getBackupCollectionForCurrentDiskContents();
+
+        $this->assertCount(0, $backups);
     }
 
     protected function getBackupCollectionForCurrentDiskContents(): BackupCollection


### PR DESCRIPTION
This PR compliments #646 with a test `it_checks_mime_type_instead_of_extension`, however it also addresses an issue introduced with that PR.

After updating to the latest `spatie/laravel-backup` version, my BackBlaze disk was showing 0 backups suddenly. I discovered that [the backblaze adapter returns `false`](https://github.com/mhetreramesh/flysystem-backblaze/blob/master/src/BackblazeAdapter.php#L179-L182) for mime types. This is the [valid return value for an error](https://github.com/thephpleague/flysystem/blob/de8b364f4aada1ecfdc03c55c35bf2f42d402fc9/src/FilesystemInterface.php#L79). Looking through a [few](https://github.com/nikkiii/flysystem-acd/blob/master/src/AmazonCloudDrive.php#L324) [other](https://github.com/nao-pon/flysystem-google-drive/blob/master/src/GoogleDriveAdapter.php#L585) adapters I saw that they attempt to get the mime and then fallback to `false`.

To remedy this we are just checking for a truthy value from `mimeType()` otherwise we are falling back to the original `.zip` extension check. I added a second test for this: `it_skips_mime_type_check_if_mime_type_is_false`

Possible fix for: #654 & #612