### PR TITLE
Database dump is streamed to gzip now, saves a lot of space.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/support": "~5.5.0|~5.6.0",
         "illuminate/notifications": "~5.5.0|~5.6.0",
         "league/flysystem": "^1.0.27",
-        "spatie/db-dumper": "^2.7",
+        "spatie/db-dumper": "^2.10",
         "spatie/temporary-directory": "^1.1",
         "symfony/finder": "^3.3|^4.0"
     },

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -6,7 +6,6 @@ use Exception;
 use Carbon\Carbon;
 use Spatie\DbDumper\DbDumper;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\File;
 use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\Backup\Events\BackupHasFailed;
 use Spatie\Backup\Events\BackupWasSuccessful;
@@ -229,18 +228,14 @@ class BackupJob
 
             $fileName = "{$dbType}-{$dbName}.sql";
 
+            if (config('backup.backup.gzip_database_dump')) {
+                $fileName .= '.gz';
+                $dbDumper->enableCompression();
+            }
+
             $temporaryFilePath = $this->temporaryDirectory->path('db-dumps'.DIRECTORY_SEPARATOR.$fileName);
 
             $dbDumper->dumpToFile($temporaryFilePath);
-
-            if (config('backup.backup.gzip_database_dump')) {
-                consoleOutput()->info("Gzipping {$dbDumper->getDbName()}...");
-
-                $compressedDumpPath = Gzip::compress($temporaryFilePath);
-                File::delete($temporaryFilePath);
-
-                return $compressedDumpPath;
-            }
 
             return $temporaryFilePath;
         })->toArray();


### PR DESCRIPTION
I didn't update the changelog because I wasn't sure to update if the update would be a minor or major improvement. The doubt was because the composer.json file has been changed too, because it uses functionality that wasn't available in a version from db-dumber before the one specified. 