### PR TITLE
Require php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "illuminate/console": "~5.5.0|~5.6.0",
         "illuminate/contracts": "~5.5.0|~5.6.0",
         "illuminate/events": "~5.5.0|~5.6.0",


### PR DESCRIPTION
Since the last version, php 7.0 is no longer supported. This PR fix composer.json to prevent php 7.0 apps to DL a non compatible version.