### PR TITLE
Add instructions on how to customize the content of database dumps.

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -40,6 +40,21 @@ return [
             /*
              * The names of the connections to the databases that should be backed up
              * MySQL, PostgreSQL, SQLite and Mongo databases are supported.
+             *
+             * The content of the database dump may be customized for each connection
+             * by adding a 'dump' key to the connection settings in config/database.php.
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'excludeTables' => [
+             *                'table_to_exclude_from_backup',
+             *                'another_table_to_exclude'
+             *            ]
+             *       ]
+             * ],
+             *
+             * For a complete list of available customization options, see https://github.com/spatie/db-dumper
              */
             'databases' => [
                 'mysql',


### PR DESCRIPTION
It took me a while to figure out how to exclude a table from the dump-file, so I added a short instruction on how to customize the dump content.

I'm not sure if this is the right place to add it, or if it's the right level of detail, but I think it needs to be mentioned somewhere. Might be worth mentioning on the documentation page as well.
