### PR TITLE
Add bzip2 compress option

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -66,7 +66,7 @@ return [
          * It will use the first true value.
          */
         'gzip_database_dump' => false,
-        
+
         'bzip2_database_dump' => false,
 
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -62,9 +62,13 @@ return [
         ],
 
         /*
-         * The database dump can be gzipped to decrease diskspace usage.
+         * The database dump can be compressed to decrease diskspace usage.
+         * It will use the first true value.
          */
         'gzip_database_dump' => false,
+        
+        'bzip2_database_dump' => false,
+
 
         'destination' => [
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -235,6 +235,11 @@ class BackupJob
                 $dbDumper->enableCompression();
             }
 
+            if (config('backup.backup.bzip2_database_dump')) {
+                $fileName .= '.bz2';
+                $dbDumper->enableCompression('bzip2 -f9');
+            }
+
             $temporaryFilePath = $this->temporaryDirectory->path('db-dumps'.DIRECTORY_SEPARATOR.$fileName);
 
             $dbDumper->dumpToFile($temporaryFilePath);


### PR DESCRIPTION
Adding bzip2 to Laravel-Backup.

> bzip2 creates about 15% smaller files than gzip. bzip2 compresses somewhat slower than gzip, but seems that it hasn't prevented bzip2 from getting popular. 

For quote's source [here](https://tukaani.org/lzma/benchmarks.html)