### PR TITLE
Add bzip2 compress option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.1",
         "laravel/framework": "~5.5.0|~5.6.0|~5.7.0",
         "league/flysystem": "^1.0.27",
-        "spatie/db-dumper": "^2.10",
+        "spatie/db-dumper": "^2.11.1",
         "spatie/temporary-directory": "^1.1",
         "symfony/finder": "^3.3|^4.0"
     },

--- a/config/backup.php
+++ b/config/backup.php
@@ -62,9 +62,13 @@ return [
         ],
 
         /*
-         * The database dump can be gzipped to decrease diskspace usage.
+         * The database dump can be compressed to decrease diskspace usage.
+         * It will use the first true value.
          */
         'gzip_database_dump' => false,
+        
+        'bzip2_database_dump' => false,
+
 
         'destination' => [
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -63,12 +63,13 @@ return [
 
         /*
          * The database dump can be compressed to decrease diskspace usage.
-         * It will use the first true value.
+         *
+         * Out of the box Laravel-backup supplies
+         * Spatie\DbDumper\Compressors\GzipCompressor::class.
+         *
+         * If you do not want any compressor at all, set it to null.
          */
-        'gzip_database_dump' => false,
-        
-        'bzip2_database_dump' => false,
-
+        'compressor_for_database_dump' => null,
 
         'destination' => [
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -11,6 +11,7 @@ use Spatie\Backup\Events\BackupHasFailed;
 use Spatie\Backup\Events\BackupWasSuccessful;
 use Spatie\Backup\Events\BackupZipWasCreated;
 use Spatie\Backup\Exceptions\InvalidBackupJob;
+use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Spatie\Backup\Events\BackupManifestWasCreated;
 use Spatie\Backup\BackupDestination\BackupDestination;
@@ -231,8 +232,13 @@ class BackupJob
             $fileName = "{$dbType}-{$dbName}.sql";
 
             if (config('backup.backup.gzip_database_dump')) {
-                $fileName .= '.gz';
-                $dbDumper->enableCompression();
+                $dbDumper->useCompressor(new GzipCompressor());
+                $fileName .= '.'.$dbDumper->getCompressorExtension();
+            }
+
+            if ($compressor = config('compressor_for_database_dump')) {
+                $dbDumper->useCompressor(new $compressor());
+                $fileName .= '.'.$dbDumper->getCompressorExtension();
             }
 
             $temporaryFilePath = $this->temporaryDirectory->path('db-dumps'.DIRECTORY_SEPARATOR.$fileName);


### PR DESCRIPTION
Adding bzip2 to Laravel-Backup.

> bzip2 creates about 15% smaller files than gzip. bzip2 compresses somewhat slower than gzip, but seems that it hasn't prevented bzip2 from getting popular. 

For quote's source [here](https://tukaani.org/lzma/benchmarks.html)

Edit: bzip2 can be imported with [Sequel Pro](https://sequelpro.com/) as with gzip