### PR TITLE
Remove drive letter and correct path separator, fixes Windows issues

### DIFF
--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -33,15 +33,22 @@ class Zip
 
     protected static function determineNameOfFileInZip(string $pathToFile, string $pathToZip)
     {
-        $zipDirectory = pathinfo($pathToZip, PATHINFO_DIRNAME);
+        $result = $pathToFile;
 
+        $zipDirectory = pathinfo($pathToZip, PATHINFO_DIRNAME);
         $fileDirectory = pathinfo($pathToFile, PATHINFO_DIRNAME);
 
         if (starts_with($fileDirectory, $zipDirectory)) {
-            return str_replace($zipDirectory, '', $pathToFile);
+            $result = str_replace($zipDirectory, '', $result);
         }
 
-        return $pathToFile;
+        /* remove drive letter */
+        $result = preg_match('/^[A-Z]:/i', $result) ? substr($result, 2) : $result;
+
+        /* only use / path separator */
+        $result = str_replace('\\', '/', $result);
+
+        return $result;
     }
 
     public function __construct(string $pathToZip)

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -10,6 +10,19 @@ class TestHelper
     /** @var \Illuminate\Filesystem\Filesystem */
     protected $filesystem;
 
+    /**
+     * Call method on object, useful for calling protected methods
+     */
+    public static function callMethod($obj, $name, array $args)
+    {
+        $class = new \ReflectionClass($obj);
+
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($obj, $args);
+    }
+
     public function __construct()
     {
         $this->filesystem = new Filesystem();

--- a/tests/Unit/ZipTest.php
+++ b/tests/Unit/ZipTest.php
@@ -49,4 +49,21 @@ class ZipTest extends TestCase
 
         $this->assertNotEquals(0, $this->zip->size());
     }
+
+
+    /** @test */
+    public function it_can_determine_name_of_file_in_zip()
+    {
+        $this->assertEquals(
+            '/Users/jon.doe/Documents/GitHub/laravel-backup/tests/temp/.gitignore',
+            $this->testHelper->callMethod(
+                $this->zip,
+                'determineNameOfFileInZip',
+                array(
+                    'C:\Users\jon.doe\Documents\GitHub\laravel-backup\tests/temp\.gitignore',
+                    'C:\Users\jon.doe\Documents\GitHub\laravel-backup\vendor\orchestra\testbench-core\src\Concerns/../../laravel\storage\app/backup-temp\temp\2016-01-01-21-01-01.zip'
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
Windows fails when drive letters exist in zip path to file.

This change removes the drive letter if it exist, and sets the path to use only / characters.

This should be backward compatible.  It fixes the test:

tests/Integration/BackupCommandTest it_includes_files_from_the_local_disks_in_the_backup

I've also added a test for determineNameOfFileInZip