### PR TITLE
Fix incorrect config compressor key name

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -236,7 +236,7 @@ class BackupJob
                 $fileName .= '.'.$dbDumper->getCompressorExtension();
             }
 
-            if ($compressor = config('database_dump_compressor')) {
+            if ($compressor = config('backup.backup.database_dump_compressor')) {
                 $dbDumper->useCompressor(new $compressor());
                 $fileName .= '.'.$dbDumper->getCompressorExtension();
             }

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -328,7 +328,7 @@ class BackupCommandTest extends TestCase
     public function it_compress_the_database_dump()
     {
         $this->app['config']->set('backup.backup.source.databases', ['sqlite']);
-        $this->app['config']->set('database_dump_compressor', GzipCompressor::class);
+        $this->app['config']->set('backup.backup.database_dump_compressor', GzipCompressor::class);
 
         $this->setUpDatabase($this->app);
 


### PR DESCRIPTION
The tests has and error, so de `BackupJob` also has it.