### PR TITLE
clear the backup-size cache (fixes #776)

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -155,4 +155,11 @@ class BackupDestination
 
         return $newestBackup->date()->gt($date);
     }
+
+    public function fresh(): BackupDestination
+    {
+        $this->backupCollectionCache = null;
+
+        return $this;
+    }
 }

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -156,7 +156,7 @@ class BackupDestination
         return $newestBackup->date()->gt($date);
     }
 
-    public function fresh(): BackupDestination
+    public function fresh(): self
     {
         $this->backupCollectionCache = null;
 

--- a/src/Tasks/Cleanup/CleanupJob.php
+++ b/src/Tasks/Cleanup/CleanupJob.php
@@ -42,7 +42,7 @@ class CleanupJob
                 $this->strategy->deleteOldBackups($backupDestination->backups());
                 $this->sendNotification(new CleanupWasSuccessful($backupDestination));
 
-                $usedStorage = Format::humanReadableSize($backupDestination->usedStorage());
+                $usedStorage = Format::humanReadableSize($backupDestination->fresh()->usedStorage());
                 consoleOutput()->info("Used storage after cleanup: {$usedStorage}.");
             } catch (Exception $exception) {
                 consoleOutput()->error("Cleanup failed because: {$exception->getMessage()}.");


### PR DESCRIPTION
when running the `artisan backup:clean` command a wrong backup size is
shown due to caching. Fixes #776