### PR TITLE
Clear cache before attempting to send notification

### DIFF
--- a/src/Notifications/BaseNotification.php
+++ b/src/Notifications/BaseNotification.php
@@ -39,6 +39,8 @@ abstract class BaseNotification extends Notification
             return collect();
         }
 
+        $backupDestination->fresh();
+
         $newestBackup = $backupDestination->newestBackup();
         $oldestBackup = $backupDestination->oldestBackup();
 

--- a/tests/Integration/CleanupCommandTest.php
+++ b/tests/Integration/CleanupCommandTest.php
@@ -219,4 +219,19 @@ class CleanupCommandTest extends TestCase
 
         $this->seeInConsoleOutput('after cleanup: 4 MB.');
     }
+
+    /** @test */
+    public function it_can_delete_zip_without_error()
+    {
+        $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 2);
+
+        // Create a temp zip file with a given size
+        $this->testHelper->createTempZipFile('mysite/test001.zip', Carbon::now()->subDays(1), 2.2);
+        $this->testHelper->createTempZipFile('mysite/test002.zip', Carbon::now()->subDays(2), 2.2);
+        $this->testHelper->createTempZipFile('mysite/test003.zip', Carbon::now()->subDays(3), 2.2);
+
+        Artisan::call('backup:clean');
+
+        $this->seeInConsoleOutput('Cleanup completed!');
+    }
 }

--- a/tests/Integration/CleanupCommandTest.php
+++ b/tests/Integration/CleanupCommandTest.php
@@ -205,4 +205,18 @@ class CleanupCommandTest extends TestCase
             'mysite/test2000.txt',
         ]);
     }
+
+    /** @test */
+    public function it_should_display_correct_used_storage_amount_after_cleanup()
+    {
+        $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 4);
+
+        collect(range(0, 10))->each(function (int $number) {
+            $this->testHelper->createTempFile1Mb("mysite/test{$number}.zip", Carbon::now()->subDays($number));
+        });
+
+        Artisan::call('backup:clean');
+
+        $this->seeInConsoleOutput('after cleanup: 4 MB.');
+    }
 }

--- a/tests/Integration/CleanupCommandTest.php
+++ b/tests/Integration/CleanupCommandTest.php
@@ -221,11 +221,10 @@ class CleanupCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_can_delete_zip_without_error()
+    public function it_can_clean_backups_and_send_notification_without_cache_error()
     {
         $this->app['config']->set('backup.cleanup.defaultStrategy.deleteOldestBackupsWhenUsingMoreMegabytesThan', 2);
 
-        // Create a temp zip file with a given size
         $this->testHelper->createTempZipFile('mysite/test001.zip', Carbon::now()->subDays(1), 2.2);
         $this->testHelper->createTempZipFile('mysite/test002.zip', Carbon::now()->subDays(2), 2.2);
         $this->testHelper->createTempZipFile('mysite/test003.zip', Carbon::now()->subDays(3), 2.2);

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -85,6 +85,27 @@ class TestHelper
         return $fullPath;
     }
 
+    public function createTempZipFile(string $fileName, DateTime $date, float $size): string
+    {
+        $directory = $this->getTempDirectory().'/'.dirname($fileName);
+
+        $this->filesystem->makeDirectory($directory, 0755, true, true);
+
+        $fullPath = $this->getTempDirectory().'/'.$fileName;
+
+        $handle = fopen($fullPath, 'w');
+
+        fseek($handle, $size * 1024 * 1024, SEEK_CUR);
+
+        fwrite($handle, '0');
+
+        fclose($handle);
+
+        touch($fullPath, $date->getTimestamp());
+
+        return $fullPath;
+    }
+
     public function createSQLiteDatabase(string $fileName): string
     {
         $directory = $this->getTempDirectory().'/'.dirname($fileName);


### PR DESCRIPTION
This pull request implements a fix for issue #746 and possibly #505.

I believe the issue is related to cached backup destinations -- if all the backup files were to be deleted, expect for the latest, and the `CleanupWasSuccessful` event were to be fired, then an exception would be thrown. This was being caused in the [BaseNotification at line 52](https://github.com/spatie/laravel-backup/blob/master/src/Notifications/BaseNotification.php#L52) when it was trying to grab the `newestBackup` size because it was using cached values.

I have also added a test which will fail if you remove the `$backupDestination->fresh();` introduced in `BaseNotification` within this PR.