### PR TITLE
Slack Webhook URL config in config null issue

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -124,6 +124,10 @@ return [
         ],
 
         'slack' => [
+            /*
+             * Avoid setting the variable in `config()` for it will return a null value.
+             * Use `env()` helper instead, or string of the url.
+             */
             'webhook_url' => '',
 
             /*


### PR DESCRIPTION
Avoid setting the variable in `config()` for it will return null value.
Use `env()` helper instead, or string of the url.

`src\Notifications\Notifiable.php@routeNotificationForSlack` is
already using `config()` helper.
Reference of the issue: 
https://blog.maqe.com/dont-use-laravel-s-config-inside-config-files-40e2c8207225