### PR TITLE
[v6] Add new health check: IncreasingFileSize

### DIFF
--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -32,4 +32,5 @@ return [
     'unhealthy_backup_found_old' => 'The latest backup made on :date is considered too old.',
     'unhealthy_backup_found_unknown' => 'Sorry, an exact reason cannot be determined.',
     'unhealthy_backup_found_full' => 'The backups are using too much storage. Current usage is :disk_usage which is higher than the allowed limit of :disk_limit.',
+    'unhealthy_backup_found_size_reduction' => 'The size of your latest backup has reduced from :from_size to :to_size (:percentage) compared to the previous backup.',
 ];

--- a/src/Tasks/Monitor/BackupDestinationStatus.php
+++ b/src/Tasks/Monitor/BackupDestinationStatus.php
@@ -55,7 +55,6 @@ class BackupDestinationStatus
     {
         $healthChecks = $this->getHealthChecks();
 
-
         foreach ($healthChecks as $healthCheck) {
             $checkResult = $this->check($healthCheck);
 

--- a/src/Tasks/Monitor/HealthChecks/IncreasingFileSize.php
+++ b/src/Tasks/Monitor/HealthChecks/IncreasingFileSize.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Spatie\Backup\Tasks\Monitor\HealthChecks;
+
+use Spatie\Backup\Helpers\Format;
+use Spatie\Backup\Tasks\Monitor\HealthCheck;
+use Spatie\Backup\BackupDestination\BackupDestination;
+
+class IncreasingFileSize extends HealthCheck
+{
+    protected $tolerance;
+
+    public function __construct($tolerance = 0.05)
+    {
+        $this->tolerance = $this->parseValue($tolerance);
+    }
+
+    public function checkHealth(BackupDestination $backupDestination)
+    {
+        if ($backupDestination->backups()->count() < 2) {
+            return;
+        }
+
+        list($newestSize, $previousSize) = [
+            $backupDestination->backups()->get(0)->size(),
+            $backupDestination->backups()->get(1)->size(),
+        ];
+
+        $relativeSize = $newestSize / $previousSize;
+        $loss = 1 - $relativeSize;
+
+        $this->failIf($loss > $this->tolerance, trans('backup::notifications.unhealthy_backup_found_size_reduction', [
+            'from_size' => Format::humanReadableSize($previousSize),
+            'to_size' => Format::humanReadableSize($newestSize),
+            'percentage' => '-'.number_format($loss * 100, 2).'%',
+        ]));
+    }
+
+    /**
+     * @param $value
+     * @return float|int
+     */
+    protected function parseValue($value)
+    {
+        if (! is_numeric($value) && preg_match('/%/', $value)) {
+            return floatval($value) / 100;
+        }
+
+        return floatval($value);
+    }
+}

--- a/tests/Integration/HealthChecks/IncreasingFileSizeTest.php
+++ b/tests/Integration/HealthChecks/IncreasingFileSizeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Spatie\Backup\Test\Integration\Inspections;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Backup\Test\Integration\TestCase;
+use Spatie\Backup\Events\HealthyBackupWasFound;
+use Spatie\Backup\Events\UnhealthyBackupWasFound;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\IncreasingFileSize;
+
+class IncreasingFileSizeTest extends TestCase
+{
+    /** @var \Carbon\Carbon */
+    protected $date;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->app['config']->set('backup.monitor_backups.0.health_checks', [
+            IncreasingFileSize::class,
+        ]);
+    }
+
+    /** @test **/
+    public function it_is_considered_healthy_when_only_one_backup_present()
+    {
+        $this->fakeNextBackupOfSize(1);
+
+        $this->expectsEvents(HealthyBackupWasFound::class);
+
+        Artisan::call('backup:monitor');
+    }
+
+    /** @test **/
+    public function it_is_considered_healthy_when_newest_backup_is_reduced_within_tolerance()
+    {
+        $this->fakeNextBackupOfSize(1, 100);
+        $this->fakeNextBackupOfSize(2, 96);
+
+        $this->expectsEvents(HealthyBackupWasFound::class);
+
+        Artisan::call('backup:monitor');
+    }
+
+    /** @test **/
+    public function it_is_considered_unhealthy_when_newest_backup_is_reduced_beyond_tolerance()
+    {
+        $this->fakeNextBackupOfSize(1, 100);
+        $this->fakeNextBackupOfSize(2, 94);
+
+        $this->expectsEvents(UnhealthyBackupWasFound::class);
+
+        Artisan::call('backup:monitor');
+    }
+
+    /** @test **/
+    public function tolerance_can_be_configured()
+    {
+        $this->app['config']->set('backup.monitor_backups.0.health_checks', [
+            IncreasingFileSize::class => '10%',
+        ]);
+
+        $this->fakeNextBackupOfSize(1, 100);
+        $this->fakeNextBackupOfSize(2, 94);
+
+        $this->expectsEvents(HealthyBackupWasFound::class);
+        Artisan::call('backup:monitor');
+
+        $this->fakeNextBackupOfSize(3, 80);
+        $this->expectsEvents(UnhealthyBackupWasFound::class);
+        Artisan::call('backup:monitor');
+    }
+
+    protected function fakeNextBackupOfSize($no, $sizeInKb = 1)
+    {
+        $this->testHelper->createTempFileWithAge(
+            "mysite/backup-{$no}.zip",
+            Carbon::now()->subSecond(10 - $no),
+            random_bytes($sizeInKb * 1024)
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a `IncreasingFileSize` health check.

If a backup reduces in size beyond a certain tolerance from the previous backup, it will raise a health warning.

This is useful if a large amount of files was accidentally deleted or moved outside the scope of the backup script.