### PR TITLE
add extra options for writeStream

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -87,6 +87,13 @@ return [
             'disks' => [
                 'local',
             ],
+
+            /*
+             *  The extra options for set file visibility, storageClass, etc
+             */
+            'extra_options' => [
+                //
+            ],
         ],
 
         /*

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -82,7 +82,9 @@ class BackupDestination
 
         $handle = fopen($file, 'r+');
 
-        $this->disk->getDriver()->writeStream($destination, $handle);
+        $options = config('backup.backup.destination.extra_options') ?? null;
+        
+        $this->disk->getDriver()->writeStream($destination, $handle, $options);
 
         if (is_resource($handle)) {
             fclose($handle);


### PR DESCRIPTION
Add optionally params for S3-compability storages. For example, you can set storageClass.