### PR TITLE
add extra options to backup destination at writeStream

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -117,7 +117,7 @@ class BackupDestination
 
     public function extraOptions(): ?array
     {
-        $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? [];
+        $extraConfig = config('filesystems.disks.'.$this->diskName().'.backup_extra_options') ?? [];
 
         if (! is_array($extraConfig) || (count($extraConfig) < 1)) {
             return [];

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -85,7 +85,7 @@ class BackupDestination
         $options = $this->extraOptions();
 
         $this->disk->getDriver()->writeStream($destination, $handle, $options);
-        
+
         if (is_resource($handle)) {
             fclose($handle);
         }
@@ -117,10 +117,10 @@ class BackupDestination
 
     public function extraOptions(): ?string
     {
-        $extraConfig =  config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
+        $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
 
-        if(!is_array($extraConfig) || (count($extraConfig) < 1))
-            return null;
+        if(! is_array($extraConfig) || (count($extraConfig) < 1))
+            return [];
 
         return $extraConfig;
     }

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -119,7 +119,7 @@ class BackupDestination
     {
         $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
 
-        if(! is_array($extraConfig) || (count($extraConfig) < 1))
+        if (! is_array($extraConfig) || (count($extraConfig) < 1))
             return [];
 
         return $extraConfig;

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -82,7 +82,10 @@ class BackupDestination
 
         $handle = fopen($file, 'r+');
 
-        $this->disk->getDriver()->writeStream($destination, $handle);
+        $options = $this->extraOptions();
+
+        $this->disk->getDriver()->writeStream($destination, $handle, $options);
+
 
         if (is_resource($handle)) {
             fclose($handle);
@@ -112,6 +115,17 @@ class BackupDestination
     {
         return $this->connectionError;
     }
+
+    public function extraOptions() : string
+    {
+        $extraConfig =  config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
+
+        if(!is_array($extraConfig) || (count($extraConfig) < 1))
+            return null;
+
+        return $extraConfig;
+    }
+
 
     public function isReachable(): bool
     {

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -117,7 +117,7 @@ class BackupDestination
 
     public function extraOptions(): ?array
     {
-        $extraConfig = config('filesystems.disks.'.$this->diskName().'.backup_extra_options') ?? [];
+        $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? [];
 
         if (! is_array($extraConfig) || (count($extraConfig) < 1)) {
             return [];

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -126,7 +126,6 @@ class BackupDestination
         return $extraConfig;
     }
 
-
     public function isReachable(): bool
     {
         if (is_null($this->disk)) {

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -115,9 +115,9 @@ class BackupDestination
         return $this->connectionError;
     }
 
-    public function extraOptions(): ?string
+    public function extraOptions(): ?array
     {
-        $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
+        $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? [];
 
         if (! is_array($extraConfig) || (count($extraConfig) < 1)) {
             return [];

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -85,8 +85,7 @@ class BackupDestination
         $options = $this->extraOptions();
 
         $this->disk->getDriver()->writeStream($destination, $handle, $options);
-
-
+        
         if (is_resource($handle)) {
             fclose($handle);
         }
@@ -116,7 +115,7 @@ class BackupDestination
         return $this->connectionError;
     }
 
-    public function extraOptions() : string
+    public function extraOptions(): ?string
     {
         $extraConfig =  config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
 

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -119,8 +119,9 @@ class BackupDestination
     {
         $extraConfig = config('filesystems.disks.'.$this->diskName().'.dump_extra_options') ?? null;
 
-        if (! is_array($extraConfig) || (count($extraConfig) < 1))
+        if (! is_array($extraConfig) || (count($extraConfig) < 1)) {
             return [];
+        }
 
         return $extraConfig;
     }

--- a/tests/Integration/BackupDestination/BackupTest.php
+++ b/tests/Integration/BackupDestination/BackupTest.php
@@ -69,8 +69,8 @@ class BackupTest extends TestCase
             'driver' => 's3',
 
             'dump_extra_options' => [
-                'StorageClass' => 'COLD'
-            ]
+                'StorageClass' => 'COLD',
+            ],
         ]);
 
         $this->app['config']->set('backup.backup.destination.disks', [

--- a/tests/Integration/BackupDestination/BackupTest.php
+++ b/tests/Integration/BackupDestination/BackupTest.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\Backup\Test\Integration\BackupDestination;
 
-use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 use Storage;
 use Carbon\Carbon;
 use Spatie\Backup\BackupDestination\Backup;
 use Spatie\Backup\Test\Integration\TestCase;
+use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 
 class BackupTest extends TestCase
 {
@@ -98,7 +98,6 @@ class BackupTest extends TestCase
         $this->assertSame([], $backupDestination->extraOptions());
     }
 
-
     protected function getBackupForFile(string $name, int $ageInDays = 0, string $contents = ''): Backup
     {
         $disk = Storage::disk('local');
@@ -113,6 +112,4 @@ class BackupTest extends TestCase
 
         return new Backup($disk, $path);
     }
-
-
 }

--- a/tests/Integration/BackupDestination/BackupTest.php
+++ b/tests/Integration/BackupDestination/BackupTest.php
@@ -68,7 +68,7 @@ class BackupTest extends TestCase
         $this->app['config']->set('filesystems.disks.s3-test-backup', [
             'driver' => 's3',
 
-            'dump_extra_options' => [
+            'backup_extra_options' => [
                 'StorageClass' => 'COLD',
             ],
         ]);

--- a/tests/Integration/BackupDestination/BackupTest.php
+++ b/tests/Integration/BackupDestination/BackupTest.php
@@ -67,9 +67,10 @@ class BackupTest extends TestCase
     {
         $this->app['config']->set('filesystems.disks.s3-test-backup', [
             'driver' => 's3',
+
             'dump_extra_options' => [
-                'StorageClass' => 'COLD',
-            ],
+                'StorageClass' => 'COLD'
+            ]
         ]);
 
         $this->app['config']->set('backup.backup.destination.disks', [
@@ -78,7 +79,7 @@ class BackupTest extends TestCase
 
         $backupDestination = BackupDestinationFactory::createFromArray(config('backup.backup'))->first();
 
-        $this->assertSame(['StorageClass' => 'COLD'], $backupDestination->extraOptions());
+        $this->assertEquals(['StorageClass' => 'COLD'], $backupDestination->extraOptions());
     }
 
     /** @test */


### PR DESCRIPTION
Add optionally params for S3-compability storages. 
For usage you should set at config/filesystems.php for your backup disk array options 'dump_extra_options', for example:
```
's3-backup' => [
            'driver' => 's3',
             ...,

            'backup_extra_options' => [
                'StorageClass' => 'COLD'
            ]
        ],
```