### PR TITLE
Updates monitor_backups.name config value

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -145,7 +145,7 @@ return [
      */
     'monitor_backups' => [
         [
-            'name' => config('app.name'),
+            'name' => env('APP_NAME'),
             'disks' => ['local'],
             'health_checks' => [
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,


### PR DESCRIPTION
In v6.0 the config value of `backup.name` changed from `config('app.name')` to `env('APP_NAME')`.

This PR makes the same change to  the `monitor_backups.name` config value.