### PR TITLE
Fix typo in english backup notification

### DIFF
--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -6,7 +6,7 @@ return [
     'exception_message_title' => 'Exception message',
     'exception_trace_title' => 'Exception trace',
 
-    'backup_failed_subject' => 'Failed back up of :application_name',
+    'backup_failed_subject' => 'Failed backup of :application_name',
     'backup_failed_body' => 'Important: An error occurred while backing up :application_name',
 
     'backup_successful_subject' => 'Successful new backup of :application_name',


### PR DESCRIPTION
Fix typo in the word "backup" when sending failed English notifications to make consistent with other spellings of the word. The consistent language may help those leveraging email filtering rules to perform actions, such as auto-forwarding and filing messages.