### PR TITLE
fix bug multiple sqlite dump-file is same name

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -222,12 +222,15 @@ class BackupJob
      */
     protected function dumpDatabases(): array
     {
-        return $this->dbDumpers->map(function (DbDumper $dbDumper) {
+        return $this->dbDumpers->map(function (DbDumper $dbDumper, $key) {
             consoleOutput()->info("Dumping database {$dbDumper->getDbName()}...");
 
             $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
 
-            $dbName = $dbDumper instanceof Sqlite ? 'database' : $dbDumper->getDbName();
+            $dbName = $dbDumper->getDbName();
+            if ($dbDumper instanceof Sqlite) {
+                $dbName = $key . '-database';
+            }
 
             $fileName = "{$dbType}-{$dbName}.sql";
 


### PR DESCRIPTION
laravel-backup always names the dump file 'sqlite-database.sql' for sqlite.
Therefore, if you have multiple SQLite databases, only one database is backed up and the other databases are not backed up.
This patch adds the connection name before "database" and backs up all databases.