### PR TITLE
fix bug multiple sqlite dump-file is same name. (Retry)

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -222,12 +222,15 @@ class BackupJob
      */
     protected function dumpDatabases(): array
     {
-        return $this->dbDumpers->map(function (DbDumper $dbDumper) {
+        return $this->dbDumpers->map(function (DbDumper $dbDumper, $key) {
             consoleOutput()->info("Dumping database {$dbDumper->getDbName()}...");
 
             $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
 
-            $dbName = $dbDumper instanceof Sqlite ? 'database' : $dbDumper->getDbName();
+            $dbName = $dbDumper->getDbName();
+            if ($dbDumper instanceof Sqlite) {
+                $dbName = $key.'-database';
+            }
 
             $fileName = "{$dbType}-{$dbName}.sql";
 

--- a/tests/Integration/BackupCommandTest.php
+++ b/tests/Integration/BackupCommandTest.php
@@ -276,7 +276,7 @@ class BackupCommandTest extends TestCase
     /** @test */
     public function it_appends_the_database_type_to_backup_file_name_to_prevent_overwrite()
     {
-        $this->app['config']->set('backup.backup.source.databases', ['sqlite']);
+        $this->app['config']->set('backup.backup.source.databases', ['db1', 'db2']);
 
         $this->setUpDatabase($this->app);
 
@@ -286,11 +286,13 @@ class BackupCommandTest extends TestCase
 
         $backupDiskLocal = $this->app['config']->get('filesystems.disks.local.root');
         $backupFileLocal = $backupDiskLocal.DIRECTORY_SEPARATOR.$this->expectedZipPath;
-        $this->assertFileExistsInZip($backupFileLocal, 'sqlite-database.sql');
+        $this->assertFileExistsInZip($backupFileLocal, 'sqlite-db1-database.sql');
+        $this->assertFileExistsInZip($backupFileLocal, 'sqlite-db2-database.sql');
 
         $backupDiskSecondLocal = $this->app['config']->get('filesystems.disks.secondLocal.root');
         $backupFileSecondLocal = $backupDiskSecondLocal.DIRECTORY_SEPARATOR.$this->expectedZipPath;
-        $this->assertFileExistsInZip($backupFileSecondLocal, 'sqlite-database.sql');
+        $this->assertFileExistsInZip($backupFileSecondLocal, 'sqlite-db1-database.sql');
+        $this->assertFileExistsInZip($backupFileSecondLocal, 'sqlite-db2-database.sql');
 
         /*
          * Close the database connection to unlock the sqlite file for deletion.
@@ -338,7 +340,7 @@ class BackupCommandTest extends TestCase
 
         $backupDiskLocal = $this->app['config']->get('filesystems.disks.local.root');
         $backupFileLocal = $backupDiskLocal.DIRECTORY_SEPARATOR.$this->expectedZipPath;
-        $this->assertFileExistsInZip($backupFileLocal, 'sqlite-database.sql.gz');
+        $this->assertFileExistsInZip($backupFileLocal, 'sqlite-sqlite-database.sql.gz');
 
         /*
          * Close the database connection to unlock the sqlite file for deletion.


### PR DESCRIPTION
laravel-backup always names the dump file 'sqlite-database.sql' for sqlite.
Therefore, if you have multiple SQLite databases, only one database is backed up and the other databases are not backed up.
This patch adds the connection name before "database" and backs up all databases.

(retry of #889)