### PR TITLE
fix bug multiple sqlite dump-file is same name. (v6)

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -223,12 +223,15 @@ class BackupJob
      */
     protected function dumpDatabases(): array
     {
-        return $this->dbDumpers->map(function (DbDumper $dbDumper) {
+        return $this->dbDumpers->map(function (DbDumper $dbDumper, $key) {
             consoleOutput()->info("Dumping database {$dbDumper->getDbName()}...");
 
             $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
 
-            $dbName = $dbDumper instanceof Sqlite ? 'database' : $dbDumper->getDbName();
+            $dbName = $dbDumper->getDbName();
+            if ($dbDumper instanceof Sqlite) {
+                $dbName = $key.'-database';
+            }
 
             $fileName = "{$dbType}-{$dbName}.{$this->getExtension($dbDumper)}";
 

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -235,15 +235,17 @@ class BackupCommandTest extends TestCase
     /** @test */
     public function it_appends_the_database_type_to_backup_file_name_to_prevent_overwrite()
     {
-        config()->set('backup.backup.source.databases', ['sqlite']);
+        config()->set('backup.backup.source.databases', ['db1', 'db2']);
 
         $this->setUpDatabase($this->app);
 
         $this->artisan('backup:run --only-db')->assertExitCode(0);
 
-        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-database.sql');
+        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-db1-database.sql');
+        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-db2-database.sql');
 
-        $this->assertFileExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-database.sql');
+        $this->assertFileExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-db1-database.sql');
+        $this->assertFileExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-db2-database.sql');
 
         /*
          * Close the database connection to unlock the sqlite file for deletion.
@@ -280,7 +282,7 @@ class BackupCommandTest extends TestCase
 
         $this->artisan('backup:run --only-db')->assertExitCode(0);
 
-        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-database.sql.gz');
+        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-sqlite-database.sql.gz');
 
         /*
          * Close the database connection to unlock the sqlite file for deletion.


### PR DESCRIPTION
laravel-backup always names the dump file 'sqlite-database.sql' for sqlite.
Therefore, if you have multiple SQLite databases, only one database is backed up and the other databases are not backed up.
This patch adds the connection name before "database" and backs up all databases.

(This PR is same as #892. target to v6.)