### PR TITLE
Add support to add custom dumpers to DbDumperFactory

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -13,6 +13,8 @@ use Spatie\Backup\Exceptions\CannotCreateDbDumper;
 
 class DbDumperFactory
 {
+    protected static $custom = [];
+
     public static function createFromConnection(string $dbConnectionName): DbDumper
     {
         $dbConfig = config("database.connections.{$dbConnectionName}");
@@ -49,9 +51,18 @@ class DbDumperFactory
         return $dbDumper;
     }
 
+    public static function extend(string $driver, callable $callback)
+    {
+        static::$custom[$driver] = $callback;
+    }
+
     protected static function forDriver($dbDriver): DbDumper
     {
         $driver = strtolower($dbDriver);
+
+        if (isset(static::$custom[$driver])) {
+            return (static::$custom[$driver])();
+        }
 
         if ($driver === 'mysql' || $driver === 'mariadb') {
             return new MySql();

--- a/tests/DbDumperFactoryTest.php
+++ b/tests/DbDumperFactoryTest.php
@@ -160,6 +160,16 @@ class DbDumperFactoryTest extends TestCase
         $this->assertStringContainsString($dumpConfig['add_extra_option'], $this->getDumpCommand());
     }
 
+    /** @test */
+    public function it_can_create_instances_of_custom_dumpers()
+    {
+        DbDumperFactory::extend('mysql', function () {
+            return new MongoDb();
+        });
+
+        $this->assertInstanceOf(MongoDb::class, DbDumperFactory::createFromConnection('mysql'));
+    }
+
     protected function getDumpCommand(): string
     {
         $dumpFile = '';


### PR DESCRIPTION
This feature adds a way to add custom database dumpers. In my case this is useful, because we are dealing with a docker container and we cannot rely on the mysql dump command outside that container (different mysql versions unfortunately). 

You can either add dumpers for custom connections:

```
DbDumperFactory::extend('some_other_connection', function() {
    return new YourCustomDumper();
});
```

Or override an existing dumper:

```
DbDumperFactory::extend('mysql', function() {
    return new YourCustomMysqlDumper();
});
```

Relevant docs update: https://github.com/spatie/docs.spatie.be/pull/411