### PR TITLE
Added password protecting zip feature

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -10,6 +10,11 @@ return [
          */
         'name' => env('APP_NAME', 'laravel-backup'),
 
+        /*
+        * Password protect the zip, no password will be used if the password is null or a empty string.
+        */
+        'password' => null,
+
         'source' => [
 
             'files' => [

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -99,8 +99,8 @@ class Zip
      */
     public function setPassword(?string $password): self
     {
-        if (!empty($password) && !method_exists(ZipArchive::class, 'setEncryptionName')) {
-            consoleOutput()->warn('Password encryption requires PHP 7.2 >= and libzip-dev >= 1.2.0');
+        if (! empty($password) && ! method_exists(ZipArchive::class, 'setEncryptionName')) {
+            consoleOutput()->info('Password encryption requires PHP 7.2 >= and libzip-dev >= 1.2.0');
 
             return $this;
         }
@@ -121,8 +121,8 @@ class Zip
             return $this;
         }
 
-        if (!$this->zipFile->setEncryptionName($nameInZip, ZipArchive::EM_AES_256, $this->password)) {
-            consoleOutput()->warn("Cannot password protect {$nameInZip}");
+        if (! $this->zipFile->setEncryptionName($nameInZip, ZipArchive::EM_AES_256, $this->password)) {
+            consoleOutput()->error("Cannot password protect {$nameInZip}");
         }
 
         return $this;

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -99,6 +99,12 @@ class Zip
      */
     public function setPassword(?string $password): self
     {
+        if (!empty($password) && !method_exists(ZipArchive::class, 'setEncryptionName')) {
+            consoleOutput()->warn('Password encryption requires PHP 7.2 >= and libzip-dev >= 1.2.0');
+
+            return $this;
+        }
+
         $this->password = $password;
 
         return $this;
@@ -116,7 +122,7 @@ class Zip
         }
 
         if (!$this->zipFile->setEncryptionName($nameInZip, ZipArchive::EM_AES_256, $this->password)) {
-            consoleOutput()->warn('Cannot password protect ' . $nameInZip);
+            consoleOutput()->warn("Cannot password protect {$nameInZip}");
         }
 
         return $this;

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Backup\Tests;
 
-use Spatie\Backup\Tasks\Backup\Zip;
 use ZipArchive;
+use Spatie\Backup\Tasks\Backup\Zip;
 
 class ZipTest extends TestCase
 {

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -58,17 +58,21 @@ class ZipTest extends TestCase
 
         $this->assertTrue($zipToTest->open($this->pathToZip));
 
-        // Check if we cannot read the file because no password is given
-        $this->assertFalse($zipToTest->getFromName($zipFilename));
-        $this->assertEquals('No password provided', $zipToTest->getStatusString());
+        if (method_exists(ZipArchive::class, 'setEncryptionName')) {
+            // Check if we cannot read the file because no password is given
+            $this->assertFalse($zipToTest->getFromName($zipFilename));
+            $this->assertEquals('No password provided', $zipToTest->getStatusString());
 
-        // Check if we cannot read the file because a invalid password is given
-        $zipToTest->setPassword('invalid password');
-        $this->assertFalse($zipToTest->getFromName($zipFilename));
-        $this->assertEquals('Wrong password provided', $zipToTest->getStatusString());
+            // Check if we cannot read the file because a invalid password is given
+            $zipToTest->setPassword('invalid password');
+            $this->assertFalse($zipToTest->getFromName($zipFilename));
+            $this->assertEquals('Wrong password provided', $zipToTest->getStatusString());
 
-        // Check if we cannot read the file because a invalid password is given
-        $zipToTest->setPassword('password');
-        $this->assertNotEmpty($zipToTest->getFromName($zipFilename));
+            // Check if we cannot read the file because a invalid password is given
+            $zipToTest->setPassword('password');
+            $this->assertNotEmpty($zipToTest->getFromName($zipFilename));
+        } else {
+            $this->assertNotEmpty($zipToTest->getFromName($zipFilename));
+        }
     }
 }


### PR DESCRIPTION
This feature adds a option to password protect a zip with the Ziparchive::setEncryptionName. The password can be set in the config. If the password is null or empty the zip will not be protected. 