### PR TITLE
Add example on how to use useSingleTransaction to avoid locking DB's

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -53,6 +53,7 @@ return [
              *            ]
              *       ]
              * ],
+			 * 'useSingleTransaction' => true, // Can be used when using only InnoDB tables, to avoid locking the DB.
              *
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper
              */

--- a/config/backup.php
+++ b/config/backup.php
@@ -51,9 +51,19 @@ return [
              *                'table_to_exclude_from_backup',
              *                'another_table_to_exclude'
              *            ]
-             *       ]
+             *       ],
              * ],
-			 * 'useSingleTransaction' => true, // Can be used when using only InnoDB tables, to avoid locking the DB.
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,
+             *       ],
+             * ],
              *
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper
              */

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -74,7 +74,17 @@ return [
              *                'another_table_to_exclude'
              *            ]
              *       ],
-             *       'useSingleTransaction' => true // Can be used when using only InnoDB tables, to avoid locking the DB.
+             * ],
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can 
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,             
+             *       ],
              * ],
              *
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -73,7 +73,8 @@ return [
              *                'table_to_exclude_from_backup',
              *                'another_table_to_exclude'
              *            ]
-             *       ]
+             *       ],
+             *       'useSingleTransaction' => true // Can be used when using only InnoDB tables, to avoid locking the DB.
              * ],
              *
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper


### PR DESCRIPTION
I was looking on how to implement this option myself, as I backup DB's that are ~3GB in size, and with locking the tables it takes a while before they're available again.