### PR TITLE
Prevent excessive IO calls by caching Backup properties

### DIFF
--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -47,7 +47,6 @@ class Backup
     {
         if ($this->date === null) {
             $this->date = Carbon::createFromTimestamp($this->disk->lastModified($this->path));
-            $this->exists = true;
         }
 
         return $this->date;
@@ -64,7 +63,6 @@ class Backup
             }
 
             $this->size = $this->disk->size($this->path);
-            $this->exists = true;
         }
 
         return $this->size;
@@ -78,8 +76,6 @@ class Backup
     public function delete()
     {
         $this->exists = null;
-        $this->date = null;
-        $this->size = null;
 
         $this->disk->delete($this->path);
 


### PR DESCRIPTION
Hi, I whipped this up quickly after running into S3 rate limit issues (see also #783 #618)

The number of calls made to the storage backend seemed a bit high to me, and by caching these properties I managed to reduce them 4-fold.

I hope this is an acceptable patch to you. Of course caching these properties makes you prone to some invalid states such as running deletes outside the knowledge of the `Backup` file, but as far as I can see this is currently not happening.