### PR TITLE
Fix backup stopping on notification failure (#960)

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -275,7 +275,11 @@ class BackupJob
     protected function sendNotification($notification)
     {
         if ($this->sendNotifications) {
-            event($notification);
+            try {
+                event($notification);
+            } catch (Exception $exception) {
+                consoleOutput()->error("Sending notification failed because: {$exception->getMessage()}.");
+            }
         }
     }
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -275,11 +275,11 @@ class BackupJob
     protected function sendNotification($notification)
     {
         if ($this->sendNotifications) {
-            try {
+            rescue(function() use ($notification) {
                 event($notification);
-            } catch (Exception $exception) {
-                consoleOutput()->error("Sending notification failed because: {$exception->getMessage()}.");
-            }
+            }, function() {
+                consoleOutput()->error("Sending notification failed");
+            });
         }
     }
 


### PR DESCRIPTION
This ensures backups continue even if there is a notification failure (#960) and dumps the error to console. 

It doesn't distinguish which notification failed though. Not sure if that is an issue.

Hope this helps. Thank you for a great package!