### PR TITLE
[Feature] Allowing to customize the destination path when publishing the translations

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -222,4 +222,5 @@ return [
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],
     ],
+
 ];

--- a/src/BackupServiceProvider.php
+++ b/src/BackupServiceProvider.php
@@ -20,7 +20,7 @@ class BackupServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__.'/../resources/lang' => resource_path('lang/vendor/backup'),
+            __DIR__.'/../resources/lang' => "{$this->app['path.lang']}/vendor/backup",
         ]);
 
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang/', 'backup');


### PR DESCRIPTION
I've a custom laravel folder structure and there is no way on how to customize the published files (translations) destination.

![laravel-custom-folder-structure](https://user-images.githubusercontent.com/3282340/65767423-bf3d0e80-e125-11e9-82f6-9d3bd1604526.jpg)

As mentioned in the title, this PR adds this feature.