### PR TITLE
Fix email notifications not being sent

### DIFF
--- a/src/Notifications/Notifications/BackupHasFailed.php
+++ b/src/Notifications/Notifications/BackupHasFailed.php
@@ -17,7 +17,7 @@ class BackupHasFailed extends BaseNotification
     {
         $mailMessage = (new MailMessage)
             ->error()
-            ->from(config('backup.mail.from.address', 'mail.from.address'), config('backup.mail.from.name', 'mail.from.name'))
+            ->from(config('backup.notifications.mail.from.address', config('mail.from.address')), config('backup.notifications.mail.from.name', config('mail.from.name')))
             ->subject(trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.backup_failed_body', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))

--- a/src/Notifications/Notifications/BackupWasSuccessful.php
+++ b/src/Notifications/Notifications/BackupWasSuccessful.php
@@ -16,7 +16,7 @@ class BackupWasSuccessful extends BaseNotification
     public function toMail(): MailMessage
     {
         $mailMessage = (new MailMessage)
-            ->from(config('backup.mail.from.address', 'mail.from.address'), config('backup.mail.from.name', 'mail.from.name'))
+            ->from(config('backup.notifications.mail.from.address', config('mail.from.address')), config('backup.notifications.mail.from.name', config('mail.from.name')))
             ->subject(trans('backup::notifications.backup_successful_subject', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.backup_successful_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]));
 

--- a/src/Notifications/Notifications/CleanupHasFailed.php
+++ b/src/Notifications/Notifications/CleanupHasFailed.php
@@ -17,7 +17,7 @@ class CleanupHasFailed extends BaseNotification
     {
         $mailMessage = (new MailMessage)
             ->error()
-            ->from(config('backup.mail.from.address', 'mail.from.address'), config('backup.mail.from.name', 'mail.from.name'))
+            ->from(config('backup.notifications.mail.from.address', config('mail.from.address')), config('backup.notifications.mail.from.name', config('mail.from.name')))
             ->subject(trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.cleanup_failed_body', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))

--- a/src/Notifications/Notifications/CleanupWasSuccessful.php
+++ b/src/Notifications/Notifications/CleanupWasSuccessful.php
@@ -16,7 +16,7 @@ class CleanupWasSuccessful extends BaseNotification
     public function toMail(): MailMessage
     {
         $mailMessage = (new MailMessage)
-            ->from(config('backup.mail.from.address', 'mail.from.address'), config('backup.mail.from.name', 'mail.from.name'))
+            ->from(config('backup.notifications.mail.from.address', config('mail.from.address')), config('backup.notifications.mail.from.name', config('mail.from.name')))
             ->subject(trans('backup::notifications.cleanup_successful_subject', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.cleanup_successful_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]));
 

--- a/src/Notifications/Notifications/HealthyBackupWasFound.php
+++ b/src/Notifications/Notifications/HealthyBackupWasFound.php
@@ -16,7 +16,7 @@ class HealthyBackupWasFound extends BaseNotification
     public function toMail(): MailMessage
     {
         $mailMessage = (new MailMessage)
-            ->from(config('backup.mail.from.address', 'mail.from.address'), config('backup.mail.from.name', 'mail.from.name'))
+            ->from(config('backup.notifications.mail.from.address', config('mail.from.address')), config('backup.notifications.mail.from.name', config('mail.from.name')))
             ->subject(trans('backup::notifications.healthy_backup_found_subject', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]))
             ->line(trans('backup::notifications.healthy_backup_found_body', ['application_name' => $this->applicationName()]));
 

--- a/src/Notifications/Notifications/UnhealthyBackupWasFound.php
+++ b/src/Notifications/Notifications/UnhealthyBackupWasFound.php
@@ -18,7 +18,7 @@ class UnhealthyBackupWasFound extends BaseNotification
     {
         $mailMessage = (new MailMessage)
             ->error()
-            ->from(config('backup.mail.from.address', 'mail.from.address'), config('backup.mail.from.name', 'mail.from.name'))
+            ->from(config('backup.notifications.mail.from.address', config('mail.from.address')), config('backup.notifications.mail.from.name', config('mail.from.name')))
             ->subject(trans('backup::notifications.unhealthy_backup_found_subject', ['application_name' => $this->applicationName()]))
             ->line(trans('backup::notifications.unhealthy_backup_found_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]))
             ->line($this->problemDescription());


### PR DESCRIPTION
There is an error in the config key and when the package tries to send the notification an exception is thrown: Cleanup failed because: Address in mailbox given [mail.from.address] does not comply with RFC 2822, 3.6.2..