### PR TITLE
Add disk getter function on Backup

### DIFF
--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -29,6 +29,11 @@ class Backup
         $this->path = $path;
     }
 
+    public function disk(): Filesystem
+    {
+        return $this->disk;
+    }
+
     public function path(): string
     {
         return $this->path;

--- a/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
+++ b/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
@@ -84,9 +84,7 @@ class DefaultStrategy extends CleanupStrategy
             $groupedBackupsByDateProperty->each(function (Collection $group) {
                 $group->shift();
 
-                $group->each(function (Backup $backup) {
-                    $backup->delete();
-                });
+                $group->each->delete();
             });
         });
     }
@@ -95,9 +93,7 @@ class DefaultStrategy extends CleanupStrategy
     {
         $backups->filter(function (Backup $backup) use ($endDate) {
             return $backup->exists() && $backup->date()->lt($endDate);
-        })->each(function (Backup $backup) {
-            $backup->delete();
-        });
+        })->each->delete();
     }
 
     protected function removeOldBackupsUntilUsingLessThanMaximumStorage(BackupCollection $backups)

--- a/tests/BackupDestination/BackupTest.php
+++ b/tests/BackupDestination/BackupTest.php
@@ -11,6 +11,16 @@ use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 class BackupTest extends TestCase
 {
     /** @test */
+    public function it_can_determine_the_disk_of_the_backup()
+    {
+        $fileName = 'test.zip';
+
+        $backup = $this->getBackupForFile($fileName);
+
+        $this->assertSame(Storage::disk('local'), $backup->disk());
+    }
+
+    /** @test */
     public function it_can_determine_the_path_of_the_backup()
     {
         $fileName = 'test.zip';


### PR DESCRIPTION
This PR allows you to read `disk()` on `Backup` which helps when writing your own `CleanupStrategy`

```php
class MyCleanupStrategy extends DefaultStrategy
{
    public function deleteOldBackups(BackupCollection $backups)
    {
        // backups can only be from one disk per call, but all go through this function
        [$s3Backups, $dropboxBackups] = $backups->partition(
            function (Backup $backup) {
                return $backup->disk() === 's3';
            }
        );

        // s3 backups follow the DefaultStrategy
        parent::deleteOldBackups($s3Backups);

        // only keep the latest Dropbox backup
        $dropboxBackups->shift();
        $dropboxBackups->each->delete();
    }
}
```