### PR TITLE
Handle database urls for database connections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,14 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/console": "~5.8.0|^6.0",
-        "illuminate/contracts": "~5.8.0|^6.0",
-        "illuminate/events": "~5.8.0|^6.0",
-        "illuminate/filesystem": "~5.8.0|^6.0",
-        "illuminate/notifications": "~5.8.0|^6.0",
-        "illuminate/support": "~5.8.0|^6.0",
+        "illuminate/console": "^5.8.15|^6.0",
+        "illuminate/contracts": "^5.8.15|^6.0",
+        "illuminate/events": "^5.8.15|^6.0",
+        "illuminate/filesystem": "^5.8.15|^6.0",
+        "illuminate/notifications": "^5.8.15|^6.0",
+        "illuminate/support": "^5.8.15|^6.0",
         "league/flysystem": "^1.0.49",
+        "orchestra/testbench": "3.8.*",
         "spatie/db-dumper": "^2.12",
         "spatie/temporary-directory": "^1.1",
         "symfony/finder": "^4.2"
@@ -34,7 +35,6 @@
         "laravel/slack-notification-channel": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3.8.0|^4.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -10,7 +10,7 @@ use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\PostgreSql;
-use Illuminate\Database\ConfigurationUrlParser;
+use Illuminate\Support\ConfigurationUrlParser;
 use Spatie\Backup\Exceptions\CannotCreateDbDumper;
 
 class DbDumperFactory

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -10,7 +10,7 @@ use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\PostgreSql;
-use Illuminate\Support\ConfigurationUrlParser;
+use Illuminate\Database\ConfigurationUrlParser;
 use Spatie\Backup\Exceptions\CannotCreateDbDumper;
 
 class DbDumperFactory

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -3,7 +3,6 @@
 namespace Spatie\Backup\Tasks\Backup;
 
 use Exception;
-use Illuminate\Database\ConfigurationUrlParser;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Spatie\DbDumper\DbDumper;
@@ -11,6 +10,7 @@ use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\PostgreSql;
+use Illuminate\Database\ConfigurationUrlParser;
 use Spatie\Backup\Exceptions\CannotCreateDbDumper;
 
 class DbDumperFactory

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Backup\Tasks\Backup;
 
+use Exception;
+use Illuminate\Database\ConfigurationUrlParser;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Spatie\DbDumper\DbDumper;
@@ -17,7 +19,12 @@ class DbDumperFactory
 
     public static function createFromConnection(string $dbConnectionName): DbDumper
     {
-        $dbConfig = config("database.connections.{$dbConnectionName}");
+        $parser = new ConfigurationUrlParser();
+        try {
+            $dbConfig = $parser->parseConfiguration(config("database.connections.{$dbConnectionName}"));
+        } catch (Exception $e) {
+            throw CannotCreateDbDumper::unsupportedDriver($dbConnectionName);
+        }
 
         if (isset($dbConfig['read'])) {
             $dbConfig = Arr::except(

--- a/tests/DbDumperFactoryTest.php
+++ b/tests/DbDumperFactoryTest.php
@@ -31,6 +31,20 @@ class DbDumperFactoryTest extends TestCase
                 'mongodb_user_auth' => 'admin',
             ],
         ]);
+
+        config()->set('database.connections.pgsql', [
+            'driver'   => 'pgsql',
+            'url'      => 'pgsql://homestead:password:15432@localhost/homestead',
+            'host'     => '127.0.0.1',
+            'port'     => '5432',
+            'database' => 'forge',
+            'username' => 'forge',
+            'password' => '',
+            'charset'  => 'utf8',
+            'prefix'   => '',
+            'schema'   => 'public',
+            'sslmode'  => 'prefer',
+        ]);
     }
 
     /** @test */
@@ -68,6 +82,25 @@ class DbDumperFactoryTest extends TestCase
         ];
         config()->set('database.connections.mongodb', $dbConfig);
         $this->assertInstanceOf(MongoDb::class, DbDumperFactory::createFromConnection('mongodb'));
+    }
+
+    /** @test */
+    public function it_can_create_instance_from_database_url()
+    {
+        $dbConfig = [
+            'driver'   => 'pgsql',
+            'host'     => 'localhost',
+            'port'     => '15432',
+            'database' => 'forge',
+            'username' => 'homestead',
+            'password' => 'password',
+            'charset'  => 'utf8',
+            'prefix'   => '',
+            'schema'   => 'public',
+            'sslmode'  => 'prefer',
+        ];
+        config()->set('database.connections.pgsql', $dbConfig);
+        $this->assertInstanceOf(PostgreSql::class, DbDumperFactory::createFromConnection('pgsql'));
     }
 
     /** @test */


### PR DESCRIPTION
Added ability to handle database urls for database connections introduced in [Laravel v5.8.15](https://github.com/laravel/framework/blob/master/CHANGELOG-5.8.md#v5815-2019-04-27)
Tests are provided. 