### PR TITLE
Revert change of orchestra/testbench in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "illuminate/notifications": "^5.8.15|^6.0",
         "illuminate/support": "^5.8.15|^6.0",
         "league/flysystem": "^1.0.49",
-        "orchestra/testbench": "3.8.*",
         "spatie/db-dumper": "^2.12",
         "spatie/temporary-directory": "^1.1",
         "symfony/finder": "^4.2"
@@ -35,6 +34,7 @@
         "laravel/slack-notification-channel": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0",
         "mockery/mockery": "^1.0",
+        "orchestra/testbench": "~3.8.0|^4.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
When #980 was merged, it moved `orchestra/testbench` from `require-dev` to `require`.

Fixes #983 

cc @chelout 