### PR TITLE
Monitor command should fail in CI if backups are considered unhealthy

### DIFF
--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -31,7 +31,7 @@ class MonitorCommand extends BaseCommand
 
             $this->error("The backups on {$diskName} are considered unhealthy!");
             event(new UnHealthyBackupWasFound($backupDestinationStatus));
-            
+
             return 1;
         });
     }

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -31,6 +31,8 @@ class MonitorCommand extends BaseCommand
 
             $this->error("The backups on {$diskName} are considered unhealthy!");
             event(new UnHealthyBackupWasFound($backupDestinationStatus));
+            
+            return 1;
         });
     }
 }


### PR DESCRIPTION
I would like to use Gitlab scheduled pipelines to monitor my application backups, but `php artisan backup:monitor` returns 0 whatever the result. With my suggestion, my pipeline will fail as excpected.