### PR TITLE
Fix non zero error code in monitoring command

### DIFF
--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -4,7 +4,6 @@ namespace Spatie\Backup\Commands;
 
 use Spatie\Backup\Events\HealthyBackupWasFound;
 use Spatie\Backup\Events\UnhealthyBackupWasFound;
-use Spatie\Backup\Tasks\Monitor\BackupDestinationStatus;
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatusFactory;
 
 class MonitorCommand extends BaseCommand

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -17,22 +17,25 @@ class MonitorCommand extends BaseCommand
 
     public function handle()
     {
+        $hasError = false;
+
         $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
 
-        $statuses->each(function (BackupDestinationStatus $backupDestinationStatus) {
+        foreach ($statuses as $backupDestinationStatus) {
             $diskName = $backupDestinationStatus->backupDestination()->diskName();
 
             if ($backupDestinationStatus->isHealthy()) {
                 $this->info("The backups on {$diskName} are considered healthy.");
                 event(new HealthyBackupWasFound($backupDestinationStatus));
-
-                return;
+            } else {
+                $hasError = true;
+                $this->error("The backups on {$diskName} are considered unhealthy!");
+                event(new UnHealthyBackupWasFound($backupDestinationStatus));
             }
+        }
 
-            $this->error("The backups on {$diskName} are considered unhealthy!");
-            event(new UnHealthyBackupWasFound($backupDestinationStatus));
-
+        if ($hasError) {
             return 1;
-        });
+        }
     }
 }

--- a/tests/Events/UnhealthyBackupWasFoundTest.php
+++ b/tests/Events/UnhealthyBackupWasFoundTest.php
@@ -28,7 +28,7 @@ class UnhealthyBackupWasFoundTest extends TestCase
             ->fakeBackup()
             ->makeHealthCheckFail()
             ->artisan('backup:monitor')
-            ->assertExitCode(0);
+            ->assertExitCode(1);
 
         Event::assertDispatched(UnhealthyBackupWasFound::class);
     }
@@ -41,7 +41,7 @@ class UnhealthyBackupWasFoundTest extends TestCase
         $this
             ->fakeBackup()
             ->makeHealthCheckFail(new InvalidHealthCheck($msg = 'This is the failure reason sent to the user'))
-            ->artisan('backup:monitor')->assertExitCode(0);
+            ->artisan('backup:monitor')->(1);
 
         Notification::assertSentTo(new Notifiable(), UnhealthyBackupWasFoundNotification::class, function (UnhealthyBackupWasFoundNotification $notification) use ($msg) {
             $slack = $notification->toSlack();
@@ -69,7 +69,7 @@ class UnhealthyBackupWasFoundTest extends TestCase
             ->fakeBackup()
             ->makeHealthCheckFail()
             ->artisan('backup:monitor')
-            ->assertExitCode(0);
+            ->assertExitCode(1);
 
         Notification::assertSentTo(new Notifiable(), UnhealthyBackupWasFoundNotification::class, function (UnhealthyBackupWasFoundNotification $notification) {
             $slack = $notification->toSlack();

--- a/tests/Events/UnhealthyBackupWasFoundTest.php
+++ b/tests/Events/UnhealthyBackupWasFoundTest.php
@@ -41,7 +41,7 @@ class UnhealthyBackupWasFoundTest extends TestCase
         $this
             ->fakeBackup()
             ->makeHealthCheckFail(new InvalidHealthCheck($msg = 'This is the failure reason sent to the user'))
-            ->artisan('backup:monitor')->(1);
+            ->artisan('backup:monitor')->assertExitCode(1);
 
         Notification::assertSentTo(new Notifiable(), UnhealthyBackupWasFoundNotification::class, function (UnhealthyBackupWasFoundNotification $notification) use ($msg) {
             $slack = $notification->toSlack();

--- a/tests/HealthChecks/IsReachableTest.php
+++ b/tests/HealthChecks/IsReachableTest.php
@@ -29,7 +29,7 @@ class IsReachableTest extends TestCase
     {
         config()->set('backup.monitor_backups.0.disks', ['nonExistingDisk']);
 
-        $this->artisan('backup:monitor')->assertExitCode(0);
+        $this->artisan('backup:monitor')->assertExitCode(1);
 
         Event::assertDispatched(UnhealthyBackupWasFound::class);
     }

--- a/tests/HealthChecks/MaximumAgeInDaysTest.php
+++ b/tests/HealthChecks/MaximumAgeInDaysTest.php
@@ -35,7 +35,7 @@ class MaximumAgeInDaysTest extends TestCase
     /** @test */
     public function it_fails_when_no_backups_are_present()
     {
-        $this->artisan('backup:monitor')->assertExitCode(0);
+        $this->artisan('backup:monitor')->assertExitCode(1);
 
         Event::assertDispatched(UnhealthyBackupWasFound::class);
     }
@@ -45,7 +45,7 @@ class MaximumAgeInDaysTest extends TestCase
     {
         $this->create1MbFileOnDisk('local', 'mysite/test.zip', Carbon::now()->subSecond()->subDay());
 
-        $this->artisan('backup:monitor')->assertExitCode(0);
+        $this->artisan('backup:monitor')->assertExitCode(1);
 
         Event::assertDispatched(UnhealthyBackupWasFound::class);
     }

--- a/tests/HealthChecks/MaximumStorageInMegabytesTest.php
+++ b/tests/HealthChecks/MaximumStorageInMegabytesTest.php
@@ -37,7 +37,7 @@ class MaximumStorageInMegabytesTest extends TestCase
         $this->create1MbFileOnDisk('local', 'mysite/test_1.zip', now()->subSeconds(2));
         $this->create1MbFileOnDisk('local', 'mysite/test_2.zip', now()->subSeconds(1));
 
-        $this->artisan('backup:monitor')->assertExitCode(0);
+        $this->artisan('backup:monitor')->assertExitCode(1);
 
         Event::assertDispatched(UnhealthyBackupWasFound::class);
     }


### PR DESCRIPTION
There was an error in my last pull request, `return 1` was in the `each` function so command was always returning 0.
I refactored the function ans I TESTED IT in a CI environment.
Sorry for wasting your time.