### PR TITLE
Corrects a typo in the method name

### DIFF
--- a/src/Exceptions/NotificationCouldNotBeSent.php
+++ b/src/Exceptions/NotificationCouldNotBeSent.php
@@ -6,7 +6,7 @@ use Exception;
 
 class NotificationCouldNotBeSent extends Exception
 {
-    public static function noNotifcationClassForEvent($event): self
+    public static function noNotificationClassForEvent($event): self
     {
         $eventClass = get_class($event);
 

--- a/src/Notifications/EventHandler.php
+++ b/src/Notifications/EventHandler.php
@@ -54,7 +54,7 @@ class EventHandler
             });
 
         if (! $notificationClass) {
-            throw NotificationCouldNotBeSent::noNotifcationClassForEvent($event);
+            throw NotificationCouldNotBeSent::noNotificationClassForEvent($event);
         }
 
         return app($notificationClass)->setEvent($event);


### PR DESCRIPTION
```diff
-    public static function noNotifcationClassForEvent($event): self
+    public static function noNotificationClassForEvent($event): self
```