### PR TITLE
MySQL Socket support

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -34,7 +34,6 @@ class DbDumperFactory
         }
 
         $dbDumper = static::forDriver($dbConfig['driver'] ?? '')
-            ->setHost(Arr::first(Arr::wrap($dbConfig['host'] ?? '')))
             ->setDbName($dbConfig['database'])
             ->setUserName($dbConfig['username'] ?? '')
             ->setPassword($dbConfig['password'] ?? '');
@@ -45,6 +44,10 @@ class DbDumperFactory
 
         if ($dbDumper instanceof MongoDb) {
             $dbDumper->setAuthenticationDatabase(config('database.connections.mongodb.dump.mongodb_user_auth') ?? '');
+        }
+
+        if (isset($dbConfig['host']) && !empty($dbConfig['host'])) {
+            $dbDumper = $dbDumper->setHost(Arr::first(Arr::wrap($dbConfig['host'])));
         }
 
         if (isset($dbConfig['port'])) {


### PR DESCRIPTION
When passing the "socket" option in "dump" section of the mysql part in database.php the host part will not be ignored. Now it does, so socket connection is possible.