### PR TITLE
Add ability to define database connections using invokable class

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -70,6 +70,16 @@ return [
             'databases' => [
                 'mysql',
             ],
+
+            /*
+             * Alternatively, you may define an FQN for an invocable class that generates an array
+             * with connection names. Note that using this option will override the database list
+             * defined above entirely.
+             *
+             * E.g.
+             *      'database_generator' => App\YourNamespace\SomeGenerator::class,
+             */
+            'database_generator' => null,
         ],
 
         /*


### PR DESCRIPTION
My project is a multi-tenant / sharding setup that has a dynamic amount of database connections defined on the fly.

This PR allows me to define an invokable class in the config to determine the databases to backup.

For example:

config.php
```php
'database_generator' => \App\Support\Backups\DatabaseConnectionGenerator::class,
```

Generator
```php
<?php

namespace App\Support\Backups;

class DatabaseConnectionGenerator
{
    public function __invoke(): array
    {
         // return list of database connections
    }
}
```