### PR TITLE
MongoDB authentication uses correct connection name

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -44,7 +44,7 @@ class DbDumperFactory
         }
 
         if ($dbDumper instanceof MongoDb) {
-            $dbDumper->setAuthenticationDatabase(config('database.connections.mongodb.dump.mongodb_user_auth') ?? '');
+            $dbDumper->setAuthenticationDatabase($dbConfig['dump']['mongodb_user_auth'] ?? '');
         }
 
         if (isset($dbConfig['port'])) {


### PR DESCRIPTION
When using a custom connection name the MongoDB does not use the authentication database due to a hardcoded reference