### PR TITLE
Added support to set execution timeout

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -22,7 +22,7 @@ class BackupCommand extends BaseCommand
         $disableNotifications = $this->option('disable-notifications');
 
         if ($this->option('timeout') && is_numeric($this->option('timeout'))) {
-            set_time_limit((int)$this->option('timeout'));
+            set_time_limit((int) $this->option('timeout'));
         }
 
         try {

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -10,7 +10,7 @@ use Spatie\Backup\Tasks\Backup\BackupJobFactory;
 class BackupCommand extends BaseCommand
 {
     /** @var string */
-    protected $signature = 'backup:run {--filename=} {--only-db} {--db-name=*} {--only-files} {--only-to-disk=} {--disable-notifications}';
+    protected $signature = 'backup:run {--filename=} {--only-db} {--db-name=*} {--only-files} {--only-to-disk=} {--disable-notifications} {--timeout=}';
 
     /** @var string */
     protected $description = 'Run the backup.';
@@ -20,6 +20,10 @@ class BackupCommand extends BaseCommand
         consoleOutput()->comment('Starting backup...');
 
         $disableNotifications = $this->option('disable-notifications');
+
+        if ($this->option('timeout') && is_numeric($this->option('timeout'))) {
+            set_time_limit((int)$this->option('timeout'));
+        }
 
         try {
             $this->guardAgainstInvalidOptions();


### PR DESCRIPTION
Added the timeout parameter to set the maximum execution time, this could be useful if the amount of data to backup is big.