### PR TITLE
Avoid Errors on Unreadeable folder

### DIFF
--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -68,6 +68,7 @@ class FileSelection
         }
 
         $finder = (new Finder())
+            ->ignoreUnreadableDirs()
             ->ignoreDotFiles(false)
             ->ignoreVCS(false);
 


### PR DESCRIPTION
This change avoid errors on unreadable folder.

When iterating on folder I had permission issue. Simply adding folder you don't have access to in `backup.source.files.exclude` doesn't avoid permission issue.