### PR TITLE
Avoid Unreadable folders errors, can be set from config

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -35,6 +35,11 @@ return [
                  * Determines if symlinks should be followed.
                  */
                 'follow_links' => false,
+
+                /*
+                 * Determines if it should avoid unreadable folders.
+                 */
+                'ignore_unreadable_directories' => false,
             ],
 
             /*

--- a/src/Tasks/Backup/BackupJobFactory.php
+++ b/src/Tasks/Backup/BackupJobFactory.php
@@ -3,6 +3,7 @@
 namespace Spatie\Backup\Tasks\Backup;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Arr;
 use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 
 class BackupJobFactory
@@ -19,7 +20,8 @@ class BackupJobFactory
     {
         return FileSelection::create($sourceFiles['include'])
             ->excludeFilesFrom($sourceFiles['exclude'])
-            ->shouldFollowLinks(isset($sourceFiles['follow_links']) && $sourceFiles['follow_links']);
+            ->shouldFollowLinks(isset($sourceFiles['follow_links']) && $sourceFiles['follow_links'])
+            ->shouldIgnoreUnreadableDirs(Arr::get($sourceFiles, 'ignore_unreadable_directories', false));
     }
 
     protected static function createDbDumpers(array $dbConnectionNames): Collection

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -17,6 +17,9 @@ class FileSelection
     /** @var bool */
     protected $shouldFollowLinks = false;
 
+    /** @var bool */
+    protected $shouldIgnoreUnreadableDirs = false;
+
     /**
      * @param array|string $includeFilesAndDirectories
      *
@@ -59,6 +62,20 @@ class FileSelection
     }
 
     /**
+     * Set if it should ignore the unreadable directories.
+     *
+     * @param boolean $IgnoreUnreadableDirs
+     *
+     * @return \Spatie\Backup\Tasks\Backup\FileSelection
+     */
+    public function shouldIgnoreUnreadableDirs(bool $IgnoreUnreadableDirs): self
+    {
+        $this->shouldIgnoreUnreadableDirs = $IgnoreUnreadableDirs;
+
+        return $this;
+    }
+
+    /**
      * @return \Generator|string[]
      */
     public function selectedFiles()
@@ -68,12 +85,15 @@ class FileSelection
         }
 
         $finder = (new Finder())
-            ->ignoreUnreadableDirs()
             ->ignoreDotFiles(false)
             ->ignoreVCS(false);
 
         if ($this->shouldFollowLinks) {
             $finder->followLinks();
+        }
+
+        if ($this->shouldIgnoreUnreadableDirs) {
+            $finder->ignoreUnreadableDirs();
         }
 
         foreach ($this->includedFiles() as $includedFile) {

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -64,13 +64,13 @@ class FileSelection
     /**
      * Set if it should ignore the unreadable directories.
      *
-     * @param boolean $IgnoreUnreadableDirs
+     * @param boolean $ignoreUnreadableDirs
      *
      * @return \Spatie\Backup\Tasks\Backup\FileSelection
      */
-    public function shouldIgnoreUnreadableDirs(bool $IgnoreUnreadableDirs): self
+    public function shouldIgnoreUnreadableDirs(bool $ignoreUnreadableDirs): self
     {
-        $this->shouldIgnoreUnreadableDirs = $IgnoreUnreadableDirs;
+        $this->shouldIgnoreUnreadableDirs = $ignoreUnreadableDirs;
 
         return $this;
     }

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -68,6 +68,7 @@ class FileSelection
         }
 
         $finder = (new Finder())
+            ->ignoreUnreadableDirs()
             ->ignoreDotFiles(false)
             ->ignoreVCS(false);
 


### PR DESCRIPTION
I tried to respect the architecture and documentation, let me know if something does not respect the way of thinking of this package.

You can set `backup.source.files.ignore_unreadable_directories` in the config file.
If true, it will ignore the folders it doesn't have permission to access.
Otherwise, it will act normal and raise an error.