### PR TITLE
Reduce number of filesystem calls for Backup `exists` and `date`

### DIFF
--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -3,6 +3,8 @@
 namespace Spatie\Backup\BackupDestination;
 
 use Carbon\Carbon;
+use InvalidArgumentException;
+use Spatie\Backup\Tasks\Backup\BackupJob;
 use Illuminate\Contracts\Filesystem\Filesystem;
 
 class Backup
@@ -51,7 +53,14 @@ class Backup
     public function date(): Carbon
     {
         if ($this->date === null) {
-            $this->date = Carbon::createFromTimestamp($this->disk->lastModified($this->path));
+            try {
+                // try to parse the date from the filename
+                $basename = basename($this->path);
+                $this->date = Carbon::createFromFormat(BackupJob::FILENAME_FORMAT, $basename);
+            } catch (InvalidArgumentException $e) {
+                // if that fails, ask the (remote) filesystem
+                $this->date = Carbon::createFromTimestamp($this->disk->lastModified($this->path));
+            }
         }
 
         return $this->date;

--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -27,8 +27,8 @@ class Backup
     public function __construct(Filesystem $disk, string $path)
     {
         $this->disk = $disk;
-
         $this->path = $path;
+        $this->exists = true;
     }
 
     public function disk(): Filesystem
@@ -89,9 +89,8 @@ class Backup
 
     public function delete()
     {
-        $this->exists = null;
-
         $this->disk->delete($this->path);
+        $this->exists = false;
 
         consoleOutput()->info("Deleted backup `{$this->path}`.");
     }

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -19,6 +19,8 @@ use Spatie\TemporaryDirectory\TemporaryDirectory;
 
 class BackupJob
 {
+    public const FILENAME_FORMAT = 'Y-m-d-H-i-s.\z\i\p';
+
     /** @var \Spatie\Backup\Tasks\Backup\FileSelection */
     protected $fileSelection;
 
@@ -79,7 +81,7 @@ class BackupJob
 
     public function setDefaultFilename(): self
     {
-        $this->filename = Carbon::now()->format('Y-m-d-H-i-s').'.zip';
+        $this->filename = Carbon::now()->format(static::FILENAME_FORMAT);
 
         return $this;
     }


### PR DESCRIPTION
Implemented two improvements
- get lastmod date of backup from the filename. If that fails, ask the remote FS
- manually keep track of `exists` status

There's more room for improvement:
- use bulk deletes instead of one delete at the time
- get size and date metadata in bulk

But these require significant refactors.

Fixes #1067 and probably relates to #1059
