### PR TITLE
Update required PHP version from 7.2 to 7.3 in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation and usage
 
-This package requires PHP 7.2 and Laravel 5.8 or higher.  
+This package requires PHP 7.3 and Laravel 5.8 or higher.  
 You'll find installation instructions and full documentation on https://docs.spatie.be/laravel-backup.
 
 ## Using an older version of PHP / Laravel?
 
-If you are on a PHP version below 7.2 or a Laravel version below 5.8 just use an older version of this package. 
+If you are on a PHP version below 7.3 or a Laravel version below 5.8 just use an older version of this package. 
 
 Read the extensive [documentation on version 3](https://docs.spatie.be/laravel-backup/v3), [on version 4](https://docs.spatie.be/laravel-backup/v4) and [on version 5](https://docs.spatie.be/laravel-backup/v5). We won't introduce new features to v5 and below anymore but we will still fix bugs.
 


### PR DESCRIPTION
By the way: wouldn't it be better to introduce a bump in the required PHP version as a major release? Was quite surprised that upgrading from 6.11.1 to 6.11.2 stopped working with PHP 7.2 suddenly.