### PR TITLE
use "local_secure" instead of "local" as default storage location

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -101,7 +101,7 @@ return [
              * The disk names on which the backups will be stored.
              */
             'disks' => [
-                'local',
+                'local_secure',
             ],
         ],
 


### PR DESCRIPTION
This avoids to unexpectedly save database and code into
a public space where it should not belong.
"local_secure" disk is configured in a laravel default
skeleton and should be available. The files will go into
the storage/ folder instead of the public/ folder now.