### PR TITLE
Allow a CleanupStrategy to access its intended BackupDestination

### DIFF
--- a/src/Tasks/Cleanup/CleanupJob.php
+++ b/src/Tasks/Cleanup/CleanupJob.php
@@ -39,7 +39,10 @@ class CleanupJob
 
                 consoleOutput()->info("Cleaning backups of {$backupDestination->backupName()} on disk {$backupDestination->diskName()}...");
 
-                $this->strategy->deleteOldBackups($backupDestination->backups());
+                $this->strategy
+                    ->setBackupDestination($backupDestination)
+                    ->deleteOldBackups($backupDestination->backups());
+
                 $this->sendNotification(new CleanupWasSuccessful($backupDestination));
 
                 $usedStorage = Format::humanReadableSize($backupDestination->fresh()->usedStorage());

--- a/src/Tasks/Cleanup/CleanupStrategy.php
+++ b/src/Tasks/Cleanup/CleanupStrategy.php
@@ -11,8 +11,8 @@ abstract class CleanupStrategy
     /** @var \Illuminate\Contracts\Config\Repository */
     protected $config;
 
-    /** @var \Spatie\Backup\BackupDestination\BackupDestination|null */
-    protected $backupDestination = null;
+    /** @var \Spatie\Backup\BackupDestination\BackupDestination */
+    protected $backupDestination;
 
     public function __construct(Repository $config)
     {
@@ -34,9 +34,9 @@ abstract class CleanupStrategy
     }
 
     /**
-     * @return \Spatie\Backup\BackupDestination\BackupDestination|null
+     * @return \Spatie\Backup\BackupDestination\BackupDestination
      */
-    public function backupDestination(): ?BackupDestination
+    public function backupDestination(): BackupDestination
     {
         return $this->backupDestination;
     }

--- a/src/Tasks/Cleanup/CleanupStrategy.php
+++ b/src/Tasks/Cleanup/CleanupStrategy.php
@@ -4,11 +4,15 @@ namespace Spatie\Backup\Tasks\Cleanup;
 
 use Illuminate\Contracts\Config\Repository;
 use Spatie\Backup\BackupDestination\BackupCollection;
+use Spatie\Backup\BackupDestination\BackupDestination;
 
 abstract class CleanupStrategy
 {
     /** @var \Illuminate\Contracts\Config\Repository */
     protected $config;
+
+    /** @var \Spatie\Backup\BackupDestination\BackupDestination|null */
+    protected $backupDestination = null;
 
     public function __construct(Repository $config)
     {
@@ -16,4 +20,24 @@ abstract class CleanupStrategy
     }
 
     abstract public function deleteOldBackups(BackupCollection $backups);
+
+    /**
+     * @param \Spatie\Backup\BackupDestination\BackupDestination $backupDestination
+     *
+     * @return $this
+     */
+    public function setBackupDestination(BackupDestination $backupDestination)
+    {
+        $this->backupDestination = $backupDestination;
+
+        return $this;
+    }
+
+    /**
+     * @return \Spatie\Backup\BackupDestination\BackupDestination|null
+     */
+    public function backupDestination(): ?BackupDestination
+    {
+        return $this->backupDestination;
+    }
 }


### PR DESCRIPTION
My application backs up to two disks — local storage, and an S3 bucket. I want to keep just 7 days of backups locally, but a years' worth on S3.

I wrote a custom `CleanupStrategy` class, and set it as the strategy in the backup config file. I was intending to handle the logic for each disk in this custom class, but then realised the `CleanupJob` task only passes a `BackupCollection` to the strategy, with no (easy) way to determine where those backups are located.

This PR simply sets a `backupDestination` property on the abstract `CleanupStrategy` class, allowing custom strategies that extend this class to identify the intended backup destination and react accordingly.

This should be backwards-compatible with any classes implementing the abstract `CleanupStrategy` class.

Thanks for considering this change!