### PR TITLE
Update README.md, docs and comment in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-backup.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-backup)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-backup.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-backup)
 
-This Laravel package [creates a backup of your application](https://docs.spatie.be/laravel-backup/v6/taking-backups/overview). The backup is a zip file that contains all files in the directories you specify along with a dump of your database. The backup can be stored on [any of the filesystems you have configured in Laravel 5](http://laravel.com/docs/filesystem).
+This Laravel package [creates a backup of your application](https://docs.spatie.be/laravel-backup/v6/taking-backups/overview). The backup is a zip file that contains all files in the directories you specify along with a dump of your database. The backup can be stored on [any of the filesystems you have configured in Laravel](http://laravel.com/docs/filesystem).
 
 Feeling paranoid about backups? No problem! You can backup your application to multiple filesystems at once.
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation and usage
 
-This package requires PHP 7.3 and Laravel 5.8 or higher.
+This package requires PHP 7.3 and Laravel 6.0 or higher.
 You'll find installation instructions and full documentation on https://docs.spatie.be/laravel-backup.
 
 ## Using an older version of PHP / Laravel?
 
-If you are on a PHP version below 7.3 or a Laravel version below 5.8 just use an older version of this package.
+If you are on a PHP version below 7.3 or a Laravel version below 6.0 just use an older version of this package.
 
 Read the extensive [documentation on version 3](https://docs.spatie.be/laravel-backup/v3), [on version 4](https://docs.spatie.be/laravel-backup/v4) and [on version 5](https://docs.spatie.be/laravel-backup/v5). We won't introduce new features to v5 and below anymore but we will still fix bugs.
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -113,7 +113,7 @@ return [
 
     /*
      * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
-     * For Slack you need to install guzzlehttp/guzzle and laravel/slack-notification-channel.
+     * For Slack you need to install laravel/slack-notification-channel.
      *
      * You can also use your own notification classes, just make sure the class is named after one of
      * the `Spatie\Backup\Events` classes.

--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -5,7 +5,7 @@ weight: 4
 
 ## Taking backups
 
-A backup is a .zip file containing all files in the directories you specify and a dump of your database (MySQL and PostgreSQL are supported). The .zip file can automatically be copied over to [any of the filesystems](https://laravel.com/docs/5.3/filesystem) you have configured.
+A backup is a .zip file containing all files in the directories you specify and a dump of your database (MySQL and PostgreSQL are supported). The .zip file can automatically be copied over to [any of the filesystems](https://laravel.com/docs/8.x/filesystem) you have configured.
 
 To perform a new backup you just have to run `php artisan backup:run`. In most cases you'll want to schedule this command.
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -130,7 +130,7 @@ return [
 
     /*
      * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
-     * For Slack you need to install guzzlehttp/guzzle.
+     * For Slack you need to install laravel/slack-notification-channel.
      *
      * You can also use your own notification classes, just make sure the class is named after one of
      * the `Spatie\Backup\Events` classes.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,7 +3,7 @@ title: Introduction
 weight: 1
 ---
 
-This Laravel package creates a backup of your application. The backup is a zipfile that contains all files in the directories you specify along with a dump of your database. The backup can be stored on [any of the filesystems](https://laravel.com/docs/5.7/filesystem)  you have configured. The package can also notify you via Mail, Slack or any notification provider when something goes wrong with your backups.
+This Laravel package creates a backup of your application. The backup is a zipfile that contains all files in the directories you specify along with a dump of your database. The backup can be stored on [any of the filesystems](https://laravel.com/docs/8.x/filesystem)  you have configured. The package can also notify you via Mail, Slack or any notification provider when something goes wrong with your backups.
 
 Feeling paranoid about backups? Don't be! You can backup your application to multiple filesystems at once.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3,7 +3,7 @@ title: Requirements
 weight: 3
 ---
 
-This backup package requires **PHP 7.2**, with the [ZIP module](http://php.net/manual/en/book.zip.php) and **Laravel 5.8 or higher**. It's not compatible with Windows servers.
+This backup package requires **PHP 7.3**, with the [ZIP module](http://php.net/manual/en/book.zip.php) and **Laravel 6.0 or higher**. It's not compatible with Windows servers.
 
 If you are using an older version of Laravel, take a look at one of the previous versions of this package.
 
@@ -15,8 +15,8 @@ Make sure `pg_dump` is installed on your system if you want to backup PostgreSQL
 
 Make sure `mongodump` is installed on your system if you want to backup Mongo databases.
 
-To send notifications to Slack you'll need to install `guzzlehttp/guzzle` v6:
+To send notifications to Slack you'll need to install `laravel/slack-notification-channel`:
 
 ```bash
-composer require guzzlehttp/guzzle
+composer require laravel/slack-notification-channel
 ```

--- a/docs/sending-notifications/customizing-the-notifiable.md
+++ b/docs/sending-notifications/customizing-the-notifiable.md
@@ -3,7 +3,7 @@ title: Customizing the notifiable
 weight: 3
 ---
 
-Laravel 5.3's notifications are sent to a notifiable. A notifiable provides configuration values that determine how notifications will be sent. 
+Laravel's notifications are sent to a notifiable. A notifiable provides configuration values that determine how notifications will be sent. 
 
 By default the package uses this notifiable class: `\Spatie\Backup\Notifications\Notifiable`. This class will read out the config file. All mail notifications will be sent to the mail address specified in the `notifications.mail.to` key of the config file.
 

--- a/docs/sending-notifications/overview.md
+++ b/docs/sending-notifications/overview.md
@@ -3,7 +3,7 @@ title: Sending notifications
 weight: 1
 ---
 
-The package leverages Laravel's native notifications to let you know that your backups are ok, or not. Out of the box it can send notifications via mail and Slack (for Slack you'll need to require `guzzlehttp/guzzle` in your project). 
+The package leverages Laravel's native notifications to let you know that your backups are ok, or not. Out of the box it can send notifications via mail and Slack (for Slack you'll need to require `laravel/slack-notification-channel` in your project). 
 
 ## Configuration
 
@@ -14,7 +14,7 @@ This is the portion of the configuration that will determine when and how notifi
 
     /*
      * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
-     * For Slack you need to install guzzlehttp/guzzle.
+     * For Slack you need to install laravel/slack-notification-channel.
      *
      * You can also use your own notification classes, just make sure the class is named after one of
      * the `Spatie\Backup\Events` classes.

--- a/docs/sending-notifications/overview.md
+++ b/docs/sending-notifications/overview.md
@@ -3,7 +3,7 @@ title: Sending notifications
 weight: 1
 ---
 
-The package leverages Laravel's native notifications to let you know that your backups are ok, or not. Out of the box it can send notifications via mail and Slack (for Slack you'll need to require `laravel/slack-notification-channel` in your project). 
+The package leverages Laravel's native notifications to let you know that your backups are ok, or not. Out of the box it can send notifications via mail and Slack (for Slack you'll need to require `laravel/slack-notification-channel` in your project).
 
 ## Configuration
 
@@ -22,12 +22,12 @@ This is the portion of the configuration that will determine when and how notifi
     'notifications' => [
 
         'notifications' => [
-            \Spatie\Backup\Notifications\Notifications\BackupHasFailed::class         => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\BackupHasFailed::class => ['mail'],
             \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFound::class => ['mail'],
-            \Spatie\Backup\Notifications\Notifications\CleanupHasFailed::class        => ['mail'],
-            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessful::class     => ['mail'],
-            \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFound::class   => ['mail'],
-            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessful::class    => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\CleanupHasFailed::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessful::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFound::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessful::class => ['mail'],
         ],
 
         /*
@@ -47,6 +47,16 @@ This is the portion of the configuration that will determine when and how notifi
 
         'slack' => [
             'webhook_url' => '',
+
+            /*
+             * If this is set to null the default channel of the webhook will be used.
+             */
+            'channel' => null,
+
+            'username' => null,
+
+            'icon' => null,
+
         ],
     ],
 


### PR DESCRIPTION
- Update information about minimal required version of PHP and Laravel
- Update links to Laravel documentation to point to latest version
- Sending Slack notifications requires `laravel/slack-notification-channel`, which requires (in `composer.json`) `guzzlehttp/guzzle`. Comment in config file instructed to require both of them, and documentation didn't event mention `laravel/slack-notification-channel`. Fixed that!