### PR TITLE
add option to add files to zip-file using relative path

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -40,6 +40,13 @@ return [
                  * Determines if it should avoid unreadable folders.
                  */
                 'ignore_unreadable_directories' => false,
+
+                /*
+                 * This path is used to make directories in resulting zip-file relative
+                 * Set to false to include complete absolute path
+                 * Example: base_path()
+                 */
+                'relative_path' => false,
             ],
 
             /*

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -57,6 +57,13 @@ return [
                  * Determines if symlinks should be followed.
                  */
                 'follow_links' => false,
+
+                /*
+                 * This path is used to make directories in resulting zip-file relative
+                 * Set to false to include complete absolute path
+                 * Example: base_path()
+                 */
+                'relative_path' => false,
             ],
 
             /*

--- a/docs/taking-backups/overview.md
+++ b/docs/taking-backups/overview.md
@@ -71,6 +71,13 @@ This section of the configuration determines which files and databases will be b
               * Determines if symlinks should be followed.
               */
              'follow_links' => false,
+
+            /*
+             * This path is used to make directories in resulting zip-file relative
+             * Set to false to include complete absolute path
+             * Example: base_path()
+             */
+            'relative_path' => false,
          ],
 
          /*

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -42,6 +42,12 @@ class Zip
             return str_replace($zipDirectory, '', $pathToFile);
         }
 
+        if($relativePath = config('backup.backup.source.files.relative_path')) {
+            if (Str::startsWith($fileDirectory . '/', $relativePath)) {
+                return str_replace($relativePath, '', $pathToFile);
+            }
+        }
+
         return $pathToFile;
     }
 

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -92,6 +92,18 @@ class BackupCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_can_backup_using_relative_path()
+    {
+        config()->set('backup.backup.source.files.include', [$this->getDiskRootPath('local')]);
+        config()->set('backup.backup.source.files.relative_path', $this->getDiskRootPath('local'));
+
+        Storage::disk('local')->put('testing-file.txt', 'dummy content');
+
+        $this->artisan('backup:run --only-files')->assertExitCode(0);
+        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'testing-file.txt');
+    }
+
+    /** @test */
     public function it_excludes_the_temporary_directory_from_the_backup()
     {
         $tempDirectoryPath = storage_path('app/backup-temp/temp');


### PR DESCRIPTION
As mentioned here: https://github.com/spatie/laravel-backup/issues/132#issuecomment-219143235
And here: https://github.com/spatie/laravel-backup/issues/1065

This pull request adds an option to enter a relative path that is removed from the full path of the files in the resulting ZIP-file.