### PR TITLE
Fix to show Backup destination hiding important error message

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -74,6 +74,10 @@ class BackupDestination
 
     public function write(string $file)
     {
+        if (!is_null($this->connectionError)) {
+            throw InvalidBackupDestination::connectionError($this->diskName);
+        }
+
         if (is_null($this->disk)) {
             throw InvalidBackupDestination::diskNotSet($this->backupName);
         }

--- a/src/Exceptions/InvalidBackupDestination.php
+++ b/src/Exceptions/InvalidBackupDestination.php
@@ -10,4 +10,9 @@ class InvalidBackupDestination extends Exception
     {
         return new static("There is no disk set for the backup named `{$backupName}`.");
     }
+
+    public static function connectionError(string $diskName): self
+    {
+        return new static ("There is a connection error when trying to connect to disk named `{$diskName}`");
+    }
 }


### PR DESCRIPTION
Issue: #1126
This pull request is to show Backup destination hiding important error messages.