### PR TITLE
File extension override

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -97,6 +97,14 @@ return [
          */
         'database_dump_compressor' => null,
 
+        /*
+         * The file extension used for the database dump files.
+         *
+         * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
+         * The file extension should be specified without a leading .
+         */
+        'database_dump_file_extension' => '',        
+        
         'destination' => [
 
             /*

--- a/docs/advanced-usage/binary-database-dumps-with-postgresql.md
+++ b/docs/advanced-usage/binary-database-dumps-with-postgresql.md
@@ -1,0 +1,31 @@
+---
+title: Binary database dumps with PostgreSQL
+weight: 3
+---
+
+PostgreSQL has the ability to produce binary database dumps via the `pg_dump` command, which produce smaller files than the SQL format and are faster to restore. See the [full list](https://www.postgresql.org/docs/current/app-pgdump.html) of `pg_dump` flags.
+
+To take advantage of this, you can set the extra flags for `pg_dump` on the database connection(s) in  `app/config/database.php`.
+
+```php
+//config/database.php
+'connections' => [
+	'pgsql' => [
+		'driver'    => 'pgsql'
+		...,
+		'dump' => [
+		    ...,
+		    'add_extra_option' => '--format=c', // and any other pg_dump flags
+		]
+	],
+```
+
+Additionally, you can change the file extension of the database dump file to signify that it is not a text SQL file.
+
+```php
+//config/backup.php
+'backup' => [
+    ...,
+    'database_dump_file_extension' => 'backup', // produces a FILENAME.backup database dump
+  ],
+```

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -321,6 +321,21 @@ Here's an example for MySQL:
 	],
 ```
 
+### File extensions of database dumps
+
+By default, database dump files are named `.sql`, except for the MongoDB driver which are named `.archive`. If you would like to override this, you can set the file extension to be used in the config.
+
+For example, to save a database dump as a `.txt` file:
+```php
+//config/backup.php
+'backup' => [
+    ...,
+    'database_dump_file_extension' => 'txt',
+  ],
+```
+
+> This relates to the names of the database dump files **within** the overall backup `zip` file that is generated.
+
 ### Custom database dumpers
 
 If you need to have a custom database dumper for a driver, you can use `DbDumpFactory::extend()`. It expects the first argument to be the driver name and the second to be a callback that returns an instance of `Spatie\DbDumper\DbDumper`.

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -288,6 +288,10 @@ class BackupJob
 
     protected function getExtension(DbDumper $dbDumper): string
     {
+        if ($extension = config('backup.backup.database_dump_file_extension')) {
+            return $extension;
+        }
+
         return $dbDumper instanceof MongoDb
             ? 'archive'
             : 'sql';

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -291,7 +291,7 @@ class BackupCommandTest extends TestCase
          * This prevents the errors from other tests trying to delete and recreate the folder.
          */
         $this->app['db']->disconnect();
-    }   
+    }
     
     /** @test */
     public function it_should_trigger_the_backup_failed_event()

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -267,6 +267,33 @@ class BackupCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_renames_database_dump_file_extension_when_specified()
+    {
+        config()->set('backup.backup.source.databases', ['db1', 'db2']);
+        config()->set('backup.backup.database_dump_file_extension', 'backup');
+
+        $this->setUpDatabase($this->app);
+
+        $this->artisan('backup:run --only-db')->assertExitCode(0);
+
+        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-db1-database.backup');
+        $this->assertFileExistsInZip('local', $this->expectedZipPath, 'sqlite-db2-database.backup');
+        $this->assertFileDoesntExistsInZip('local', $this->expectedZipPath, 'sqlite-db1-database.sql');
+        $this->assertFileDoesntExistsInZip('local', $this->expectedZipPath, 'sqlite-db2-database.sql');
+
+        $this->assertFileExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-db1-database.backup');
+        $this->assertFileExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-db2-database.backup');
+        $this->assertFileDoesntExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-db1-database.sql');
+        $this->assertFileDoesntExistsInZip('secondLocal', $this->expectedZipPath, 'sqlite-db2-database.sql');
+
+        /*
+         * Close the database connection to unlock the sqlite file for deletion.
+         * This prevents the errors from other tests trying to delete and recreate the folder.
+         */
+        $this->app['db']->disconnect();
+    }   
+    
+    /** @test */
     public function it_should_trigger_the_backup_failed_event()
     {
         // use an invalid dbname to trigger failure


### PR DESCRIPTION
As per the discussion: https://github.com/spatie/laravel-backup/discussions/1204

This PR allows renaming the database dump file extension. as well as updating the documentation and a test. I've also added a documentation section about generating binary dumps with `pg_dump` that this feature is useful for.

Thanks!