### PR TITLE
Disable notifications refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 .phpunit.result.cache
 .php_cs.cache
+.idea

--- a/src/Events/BackupHasFailed.php
+++ b/src/Events/BackupHasFailed.php
@@ -5,11 +5,17 @@ namespace Spatie\Backup\Events;
 use Exception;
 use Spatie\Backup\BackupDestination\BackupDestination;
 
-class BackupHasFailed
+class BackupHasFailed implements ShouldBeNotified
 {
     public function __construct(
         public Exception $exception,
         public ?BackupDestination $backupDestination = null,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/BackupManifestWasCreated.php
+++ b/src/Events/BackupManifestWasCreated.php
@@ -4,10 +4,16 @@ namespace Spatie\Backup\Events;
 
 use Spatie\Backup\Tasks\Backup\Manifest;
 
-class BackupManifestWasCreated
+class BackupManifestWasCreated implements ShouldBeNotified
 {
     public function __construct(
         public Manifest $manifest,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/BackupWasSuccessful.php
+++ b/src/Events/BackupWasSuccessful.php
@@ -4,10 +4,16 @@ namespace Spatie\Backup\Events;
 
 use Spatie\Backup\BackupDestination\BackupDestination;
 
-class BackupWasSuccessful
+class BackupWasSuccessful implements ShouldBeNotified
 {
     public function __construct(
         public BackupDestination $backupDestination,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/BackupZipWasCreated.php
+++ b/src/Events/BackupZipWasCreated.php
@@ -2,10 +2,16 @@
 
 namespace Spatie\Backup\Events;
 
-class BackupZipWasCreated
+class BackupZipWasCreated implements ShouldBeNotified
 {
     public function __construct(
         public string $pathToZip,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/CleanupHasFailed.php
+++ b/src/Events/CleanupHasFailed.php
@@ -5,11 +5,17 @@ namespace Spatie\Backup\Events;
 use Exception;
 use Spatie\Backup\BackupDestination\BackupDestination;
 
-class CleanupHasFailed
+class CleanupHasFailed implements ShouldBeNotified
 {
     public function __construct(
         public Exception $exception,
         public ?BackupDestination $backupDestination = null,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/CleanupWasSuccessful.php
+++ b/src/Events/CleanupWasSuccessful.php
@@ -4,10 +4,16 @@ namespace Spatie\Backup\Events;
 
 use Spatie\Backup\BackupDestination\BackupDestination;
 
-class CleanupWasSuccessful
+class CleanupWasSuccessful implements ShouldBeNotified
 {
     public function __construct(
         public BackupDestination $backupDestination,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/HealthyBackupWasFound.php
+++ b/src/Events/HealthyBackupWasFound.php
@@ -4,10 +4,16 @@ namespace Spatie\Backup\Events;
 
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatus;
 
-class HealthyBackupWasFound
+class HealthyBackupWasFound implements ShouldBeNotified
 {
     public function __construct(
         public BackupDestinationStatus $backupDestinationStatus,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }

--- a/src/Events/ShouldBeNotified.php
+++ b/src/Events/ShouldBeNotified.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Backup\Events;
+
+interface ShouldBeNotified
+{
+    public function shouldBeNotified() : bool;
+}

--- a/src/Events/UnhealthyBackupWasFound.php
+++ b/src/Events/UnhealthyBackupWasFound.php
@@ -4,10 +4,16 @@ namespace Spatie\Backup\Events;
 
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatus;
 
-class UnhealthyBackupWasFound
+class UnhealthyBackupWasFound implements ShouldBeNotified
 {
     public function __construct(
-        public BackupDestinationStatus $backupDestinationStatus
+        public BackupDestinationStatus $backupDestinationStatus,
+        protected bool $shouldBeNotified = true,
     ) {
+    }
+
+    public function shouldBeNotified(): bool
+    {
+        return $this->shouldBeNotified();
     }
 }


### PR DESCRIPTION
As per #1209 issue discussion I have put in place a little notifications / events disable feature refactoring.

The `--disable-notifications` flag acts exactly as its name says, so no notification will be sent.
A new `--disable-events` flag has been introduced to actually disable events firing.

Notification cannot be sent when events firing is disabled.

Tests has been added to check this new behavior.