### PR TITLE
use LOG_SLACK_WEBHOOK_URL as default for slack notifications

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -160,7 +160,7 @@ return [
         ],
 
         'slack' => [
-            'webhook_url' => '',
+            'webhook_url' => env('LOG_SLACK_WEBHOOK_URL', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -164,7 +164,7 @@ return [
         ],
 
         'slack' => [
-            'webhook_url' => '',
+            'webhook_url' => env('LOG_SLACK_WEBHOOK_URL', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.

--- a/docs/sending-notifications/overview.md
+++ b/docs/sending-notifications/overview.md
@@ -46,7 +46,7 @@ This is the portion of the configuration that will determine when and how notifi
         ],
 
         'slack' => [
-            'webhook_url' => '',
+            'webhook_url' => env('LOG_SLACK_WEBHOOK_URL', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.


### PR DESCRIPTION
This is a minor change that defaults to use the already present LOG_SLACK_WEBHOOK_URL used by Laravel for the Slack log channel, this makes it easier to configure the slack notifications, especially if you already are using the slack log channel and wish to use the same webhook for it.

This should be a pretty safe default since slack is not enabled on any of notifications anyway, so no unwanted notifications should be sent.