### PR TITLE
fix: zip module undefined constant in config

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -135,7 +135,9 @@ return [
          * The encryption algorithm to be used for archive encryption.
          * You can set it to `null` or `false` to disable encryption.
          */
-        'encryption' => \ZipArchive::EM_AES_256,
+        "encryption" => defined("\ZipArchive::EM_AES_256")
+            ? \ZipArchive::EM_AES_256
+            : null,
     ],
 
     /*


### PR DESCRIPTION
constant \ZipArchive::EM_AES_256 isn't always present in zip module

here:
https://www.php.net/manual/en/zip.constants.php

says:
AES 256 encryption. Available as of PHP 7.2.0 and PECL zip 1.14.0, respectively, if built against libzip ≥ 1.2.0.

this can break composer dump-autoload in ran in a system with zip module
built with older libzip