### PR TITLE
Update spatie/temporary-directory package to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "league/flysystem": "^1.0.49|^2.0",
         "spatie/db-dumper": "^2.12",
         "spatie/laravel-package-tools": "^1.1",
-        "spatie/temporary-directory": "^1.1",
+        "spatie/temporary-directory": "^2.0",
         "symfony/finder": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates the `spatie/temporary-directory` package to v2.0.0, which is the latest version of the package as of this PR submission.