### PR TITLE
Update dependencies (spatie/db-dumper)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/notifications": "^8.0",
         "illuminate/support": "^8.0",
         "league/flysystem": "^1.0.49|^2.0",
-        "spatie/db-dumper": "^2.12",
+        "spatie/db-dumper": "^3.0",
         "spatie/laravel-package-tools": "^1.1",
         "spatie/temporary-directory": "^2.0",
         "symfony/finder": "^5.0"


### PR DESCRIPTION
This PR bumps the required version for `spatie/db-dumper` to 3.0, the latest version of the package as of this PR submission.