### PR TITLE
Add DumpingDatabase event

### DIFF
--- a/src/Events/DumpingDatabase.php
+++ b/src/Events/DumpingDatabase.php
@@ -6,7 +6,8 @@ use Spatie\DbDumper\DbDumper;
 
 class DumpingDatabase
 {
-    public DbDumper $dbDumper;
+    /** @var \Spatie\DbDumper\DbDumper */
+    public $dbDumper;
 
     public function __construct(DbDumper $dbDumper)
     {

--- a/src/Events/DumpingDatabase.php
+++ b/src/Events/DumpingDatabase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Backup\Events;
+
+use Spatie\DbDumper\DbDumper;
+
+class DumpingDatabase
+{
+    public DbDumper $dbDumper;
+
+    public function __construct(DbDumper $dbDumper)
+    {
+        $this->dbDumper = $dbDumper;
+    }
+}

--- a/src/Events/DumpingDatabase.php
+++ b/src/Events/DumpingDatabase.php
@@ -6,11 +6,8 @@ use Spatie\DbDumper\DbDumper;
 
 class DumpingDatabase
 {
-    /** @var \Spatie\DbDumper\DbDumper */
-    public $dbDumper;
-
-    public function __construct(DbDumper $dbDumper)
-    {
-        $this->dbDumper = $dbDumper;
+    public function __construct(
+        public DbDumper $dbDumper
+    ) {
     }
 }

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -12,6 +12,7 @@ use Spatie\Backup\Events\BackupHasFailed;
 use Spatie\Backup\Events\BackupManifestWasCreated;
 use Spatie\Backup\Events\BackupWasSuccessful;
 use Spatie\Backup\Events\BackupZipWasCreated;
+use Spatie\Backup\Events\DumpingDatabase;
 use Spatie\Backup\Exceptions\InvalidBackupJob;
 use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\MongoDb;
@@ -250,6 +251,8 @@ class BackupJob
                 }
 
                 $temporaryFilePath = $this->temporaryDirectory->path('db-dumps' . DIRECTORY_SEPARATOR . $fileName);
+
+                event(new DumpingDatabase($dbDumper));
 
                 $dbDumper->dumpToFile($temporaryFilePath);
 

--- a/tests/Events/DumpingDatabaseTest.php
+++ b/tests/Events/DumpingDatabaseTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\Backup\Tests\Events;
+
+use Illuminate\Support\Facades\Event;
+use Spatie\Backup\Events\DumpingDatabase;
+use Spatie\Backup\Tests\TestCase;
+
+class DumpingDatabaseTest extends TestCase
+{
+    /** @test */
+    public function it_will_fire_a_dumping_database_event()
+    {
+        Event::fake();
+
+        $this->artisan('backup:run');
+
+        Event::assertDispatched(DumpingDatabase::class);
+    }
+}


### PR DESCRIPTION
With this event you can customize the `DbDumper` options like `skipLockTables`, `useSingleTransaction`, etc.

(I intentionally didn't use constructor property promotion hoping that if you decide to merge it, it could also be merged into v6.)