### PR TITLE
Avoid SIGINT on Windows

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -9,7 +9,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class BaseCommand extends SignalAwareCommand
 {
-    protected array $handlesSignals = [SIGINT];
+    protected array $handlesSignals = [];
+
+    public function __construct()
+    {
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+            $this->handlesSignals[] = SIGINT;
+        }
+
+        parent::__construct();
+    }
 
     public function run(InputInterface $input, OutputInterface $output): int
     {

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -13,7 +13,7 @@ abstract class BaseCommand extends SignalAwareCommand
 
     public function __construct()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+        if (PHP_OS_FAMILY !== 'Windows') {
             $this->handlesSignals[] = SIGINT;
         }
 


### PR DESCRIPTION
PR for #1288 

Checks `PHP_OS_FAMILY` constant for "Windows" and avoids registering `SIGINT`.

Tested on Windows 10 and Fedora 33
