### PR TITLE
Detect write failures

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -86,7 +86,7 @@ class BackupDestination
 
         $handle = fopen($file, 'r+');
 
-        $this->disk->getDriver()->writeStream(
+        $result = $this->disk->getDriver()->writeStream(
             $destination,
             $handle,
             $this->getDiskOptions()
@@ -94,6 +94,10 @@ class BackupDestination
 
         if (is_resource($handle)) {
             fclose($handle);
+        }
+
+        if ($result === false) {
+            throw InvalidBackupDestination::writeError($this->diskName);
         }
     }
 

--- a/src/Exceptions/InvalidBackupDestination.php
+++ b/src/Exceptions/InvalidBackupDestination.php
@@ -15,4 +15,9 @@ class InvalidBackupDestination extends Exception
     {
         return new static ("There is a connection error when trying to connect to disk named `{$diskName}`");
     }
+
+    public static function writeError(string $diskName): self
+    {
+        return new static ("There was an error trying to write to disk named `{$diskName}`");
+    }
 }


### PR DESCRIPTION
Fixes #1326 

This is an important change, as currently laravel-backup reports all misconfigured S3 backups as successful!

This change only applies to laravel-backup v6, which uses flysystem v1 (laravel-backup v7 uses flysystem v2 which has a different interface).