### PR TITLE
adds: exception to throw when flysystem returns false

### DIFF
--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use InvalidArgumentException;
 use Spatie\Backup\Tasks\Backup\BackupJob;
+use Spatie\Backup\Exceptions\InvalidBackupFile;
 
 class Backup
 {
@@ -70,7 +71,13 @@ class Backup
 
     public function stream()
     {
-        return $this->disk->readStream($this->path);
+      $result = $this->disk->readStream($this->path);
+
+      if ($result === false) {
+        throw InvalidBackupFile::readError($this);
+      }
+
+      return $result;
     }
 
     public function delete(): void

--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -71,13 +71,10 @@ class Backup
 
     public function stream()
     {
-        $result = $this->disk->readStream($this->path);
-
-        if ($result === false) {
-          throw InvalidBackupFile::readError($this);
-        }
-
-        return $result;
+        return throw_unless(
+            $this->disk->readStream($this->path),
+            InvalidBackupFile::readError($this)
+        );
     }
 
     public function delete(): void

--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -5,8 +5,8 @@ namespace Spatie\Backup\BackupDestination;
 use Carbon\Carbon;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use InvalidArgumentException;
-use Spatie\Backup\Tasks\Backup\BackupJob;
 use Spatie\Backup\Exceptions\InvalidBackupFile;
+use Spatie\Backup\Tasks\Backup\BackupJob;
 
 class Backup
 {

--- a/src/BackupDestination/Backup.php
+++ b/src/BackupDestination/Backup.php
@@ -71,13 +71,13 @@ class Backup
 
     public function stream()
     {
-      $result = $this->disk->readStream($this->path);
+        $result = $this->disk->readStream($this->path);
 
-      if ($result === false) {
-        throw InvalidBackupFile::readError($this);
-      }
+        if ($result === false) {
+          throw InvalidBackupFile::readError($this);
+        }
 
-      return $result;
+        return $result;
     }
 
     public function delete(): void

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -93,7 +93,7 @@ class BackupDestination
         }
 
         if (! $hasWritten) {
-          throw InvalidBackupFile::writeError($this->backupName());
+            throw InvalidBackupFile::writeError($this->backupName());
         }
     }
 

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -7,6 +7,7 @@ use Exception;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Spatie\Backup\Exceptions\InvalidBackupDestination;
+use Spatie\Backup\Exceptions\InvalidBackupFile;
 
 class BackupDestination
 {
@@ -81,7 +82,7 @@ class BackupDestination
 
         $handle = fopen($file, 'r+');
 
-        $this->disk->getDriver()->writeStream(
+        $hasWritten = $this->disk->getDriver()->writeStream(
             $destination,
             $handle,
             $this->getDiskOptions()
@@ -89,6 +90,10 @@ class BackupDestination
 
         if (is_resource($handle)) {
             fclose($handle);
+        }
+
+        if (!$hasWritten) {
+          throw InvalidBackupFile::writeError($this->backupName());
         }
     }
 

--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -92,7 +92,7 @@ class BackupDestination
             fclose($handle);
         }
 
-        if (!$hasWritten) {
+        if (! $hasWritten) {
           throw InvalidBackupFile::writeError($this->backupName());
         }
     }

--- a/src/Exceptions/InvalidBackupFile.php
+++ b/src/Exceptions/InvalidBackupFile.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\Backup\Exceptions;
+
+use Spatie\Backup\BackupDestination\Backup;
+use Exception;
+
+class InvalidBackupFile extends Exception
+{
+
+    public static function writeError(string $backupName): self
+    {
+        return new static("There is have been error writing file for the backup named `{$backupName}`.");
+    }
+
+    public static function readError(Backup $backup): self
+    {
+        $backupName = basename($backup->path());
+
+        return new static("There is have been error reading file for the backup named `{$backupName}`");
+    }
+}

--- a/src/Exceptions/InvalidBackupFile.php
+++ b/src/Exceptions/InvalidBackupFile.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Backup\Exceptions;
 
-use Spatie\Backup\BackupDestination\Backup;
 use Exception;
+use Spatie\Backup\BackupDestination\Backup;
 
 class InvalidBackupFile extends Exception
 {

--- a/src/Exceptions/InvalidBackupFile.php
+++ b/src/Exceptions/InvalidBackupFile.php
@@ -7,7 +7,6 @@ use Exception;
 
 class InvalidBackupFile extends Exception
 {
-
     public static function writeError(string $backupName): self
     {
         return new static("There is have been error writing file for the backup named `{$backupName}`.");

--- a/src/Exceptions/InvalidBackupFile.php
+++ b/src/Exceptions/InvalidBackupFile.php
@@ -9,13 +9,13 @@ class InvalidBackupFile extends Exception
 {
     public static function writeError(string $backupName): self
     {
-        return new static("There is have been error writing file for the backup named `{$backupName}`.");
+        return new static("There has been an error writing file for the backup named `{$backupName}`.");
     }
 
     public static function readError(Backup $backup): self
     {
         $backupName = basename($backup->path());
 
-        return new static("There is have been error reading file for the backup named `{$backupName}`");
+        return new static("There has been an error reading file for the backup named `{$backupName}`");
     }
 }

--- a/src/Exceptions/InvalidBackupFile.php
+++ b/src/Exceptions/InvalidBackupFile.php
@@ -14,8 +14,8 @@ class InvalidBackupFile extends Exception
 
     public static function readError(Backup $backup): self
     {
-        $backupName = basename($backup->path());
+        $path = $backup->path();
 
-        return new static("There has been an error reading file for the backup named `{$backupName}`");
+        return new static("There has been an error reading the backup `{$path}`");
     }
 }

--- a/tests/BackupDestination/BackupTest.php
+++ b/tests/BackupDestination/BackupTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Backup\Tests\BackupDestination;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Backup\BackupDestination\Backup;
+use Spatie\Backup\Exceptions\InvalidBackupFile;
 use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 use Spatie\Backup\Tests\TestCase;
 
@@ -28,6 +29,16 @@ class BackupTest extends TestCase
         $backup = $this->getBackupForFile($fileName);
 
         $this->assertSame("mysite.com/{$fileName}", $backup->path());
+    }
+
+    /** @test */
+    public function it_can_get_backup_as_stream_resource()
+    {
+        $fileName = 'test.zip';
+
+        $backup = $this->getBackupForFile($fileName);
+
+        $this->assertIsResource($backup->stream());
     }
 
     /** @test */

--- a/tests/BackupDestination/BackupTest.php
+++ b/tests/BackupDestination/BackupTest.php
@@ -2,17 +2,17 @@
 
 namespace Spatie\Backup\Tests\BackupDestination;
 
-use Mockery as m;
 use Carbon\Carbon;
-use Mockery\MockInterface;
-use League\Flysystem\Filesystem;
-use League\Flysystem\Adapter\Local;
-use Illuminate\Support\Facades\Storage;
-use Spatie\Backup\BackupDestination\Backup;
 use Illuminate\Filesystem\FilesystemAdapter;
-use Spatie\Backup\Exceptions\InvalidBackupFile;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use Mockery as m;
+use Mockery\MockInterface;
+use Spatie\Backup\BackupDestination\Backup;
 use Spatie\Backup\BackupDestination\BackupDestination;
 use Spatie\Backup\BackupDestination\BackupDestinationFactory;
+use Spatie\Backup\Exceptions\InvalidBackupFile;
 use Spatie\Backup\Tests\TestCase;
 
 class BackupTest extends TestCase


### PR DESCRIPTION
fix #1326 

I have done research on this and I would like to note it here.
league/flysystem - v1: Methods in League\Flysystem\FilesystemInterface doesn't throw exceptions instead returns true, false, resource, array. In flysystem v2 there are [exceptions which will be thrown](https://flysystem.thephpleague.com/v2/docs/usage/exception-handling/) instead of returning false.

In this package only Backup@delete checks for its result for rest of the methods(writeStream, readStream) I've added checking the result and throwing exception.

Even though I tried to add tests for these cases, I find it difficult to achieve 