### PR TITLE
Support when no signal's extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-pcntl": "*",
         "ext-zip": "^1.14.0",
         "illuminate/console": "^8.36",
         "illuminate/contracts": "^8.36",
@@ -32,7 +31,7 @@
         "spatie/laravel-package-tools": "^1.6.2",
         "spatie/laravel-signal-aware-command": "^1.1",
         "spatie/temporary-directory": "^2.0",
-        "symfony/console": "^5.2.6",
+        "symfony/console": "^5.2.12",
         "symfony/finder": "^5.2"
     },
     "require-dev": {

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -51,6 +51,10 @@ class BackupCommand extends BaseCommand
                 $backupJob->disableNotifications();
             }
 
+            if (!$this->getSubscribedSignals()) {
+                $backupJob->disableSignals();
+            }
+
             $backupJob->run();
 
             consoleOutput()->comment('Backup completed!');

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -6,6 +6,7 @@ use Spatie\Backup\Helpers\ConsoleOutput;
 use Spatie\SignalAwareCommand\SignalAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 
 abstract class BaseCommand extends SignalAwareCommand
 {
@@ -13,7 +14,7 @@ abstract class BaseCommand extends SignalAwareCommand
 
     public function __construct()
     {
-        if (PHP_OS_FAMILY !== 'Windows' && $this->runningInConsole() && defined('SIGINT')) {
+        if ($this->runningInConsole() && SignalRegistry::isSupported()) {
             $this->handlesSignals[] = SIGINT;
         }
 
@@ -30,5 +31,10 @@ abstract class BaseCommand extends SignalAwareCommand
     protected function runningInConsole(): bool
     {
         return in_array(php_sapi_name(), ['cli', 'phpdbg']);
+    }
+
+    public function getSubscribedSignals(): array
+    {
+        return $this->handlesSignals;
     }
 }


### PR DESCRIPTION
Use signals only when ext-pcntl is available

It's a workaround after [Simfony/Console 681a074](https://github.com/symfony/console/commit/681a074054bc6fc00dfeb5f862f266847d9a8465), it is gonna be on the next release, This PR allows avoid signals on windows and linux without ext-pcntl, so dependency can be removed