### PR TITLE
Fix 1312 Extracted encryption process out of sendNotification

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -227,7 +227,9 @@ class BackupJob
 
         consoleOutput()->info("Created zip containing {$zip->count()} files and directories. Size is {$zip->humanReadableSize()}");
 
-        $this->sendNotification(new BackupZipWasCreated($pathToZip));
+        $this->encryptBackup($pathToZip);
+
+        $this->sendNotification($pathToZip);
 
         return $pathToZip;
     }
@@ -292,6 +294,14 @@ class BackupJob
                     $this->sendNotification(new BackupHasFailed($exception, $backupDestination ?? null));
                 }
             });
+    }
+
+    protected function encryptBackup($pathToZip): void
+    {
+        rescue(
+            fn () => event(new BackupZipWasCreated($pathToZip)),
+            consoleOutput()->info('Encrypting backup successful...')
+        );
     }
 
     protected function sendNotification($notification): void

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -229,8 +229,6 @@ class BackupJob
 
         $this->encryptBackup($pathToZip);
 
-        $this->sendNotification($pathToZip);
-
         return $pathToZip;
     }
 

--- a/tests/Events/BackupZipWasCreatedTest.php
+++ b/tests/Events/BackupZipWasCreatedTest.php
@@ -17,4 +17,17 @@ class BackupZipWasCreatedTest extends TestCase
 
         Event::assertDispatched(BackupZipWasCreated::class);
     }
+
+    /** @test */
+    public function it_will_fire_a_backup_zip_was_created_event_when_notifications_are_disabled()
+    {
+        Event::fake();
+
+        $this->artisan('backup:run', [
+            '--disable-notifications' => true,
+            '--only-files' => true
+        ]);
+
+        Event::assertDispatched(BackupZipWasCreated::class);
+    }
 }


### PR DESCRIPTION
Hello there,

This pull request is my solution for issue #1312. I pulled the encryption process from the sendNotifcation method, so the event is also fired when the command is run with the --disable-notifications parameter.

This is my first "real" contribution to open source, so any advice is welcome!