### PR TITLE
Add missing notification renaming to the changelog (7.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to `laravel-backup` will be documented in this file.
 - clean up of all internals
 - drop support for PHP 7
 - drop support for anything below Laravel 8
+- rename notification class names
 
 ## 6.14.2 - 2020-12-27
 


### PR DESCRIPTION
We were wondering about the undocumented renaming of notification classes. It is a breaking change, so we would suggest to add this important information to the changelog at least. 
