### PR TITLE
Update notification doc-block in backup.php

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -146,7 +146,7 @@ return [
      * For Slack you need to install laravel/slack-notification-channel.
      *
      * You can also use your own notification classes, just make sure the class is named after one of
-     * the `Spatie\Backup\Events` classes.
+     * the `Spatie\Backup\Notifications\Notifications` classes.
      */
     'notifications' => [
 


### PR DESCRIPTION
We are using custom notifications and renamed the class names to the event names (like described in config).
We noticed that you need to suffix the class name with `Notification`.
See: https://github.com/spatie/laravel-backup/blob/main/src/Notifications/EventHandler.php#L43-L47

So in conclusion the class name should match the original [notification class names](https://github.com/spatie/laravel-backup/tree/main/src/Notifications/Notifications) ones.

F.e. 

class_basename(`Spatie\Backup\Events\BackupHasFailed`) +  `Notification` = `BackupHasFailedNotification`

This PR changes the doc-block in the config.

