### PR TITLE
[v6] **Important** Avoid full path on db dumps

### DIFF
--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -27,7 +27,7 @@ class Zip
         $zip->open();
 
         foreach ($manifest->files() as $file) {
-            $zip->add($file, self::determineNameOfFileInZip($file, $relativePath));
+            $zip->add($file, self::determineNameOfFileInZip($file, $pathToZip, $relativePath));
         }
 
         $zip->close();
@@ -35,9 +35,15 @@ class Zip
         return $zip;
     }
 
-    protected static function determineNameOfFileInZip(string $pathToFile, string $relativePath)
+    protected static function determineNameOfFileInZip(string $pathToFile, string $pathToZip, string $relativePath)
     {
         $fileDirectory = pathinfo($pathToFile, PATHINFO_DIRNAME) . DIRECTORY_SEPARATOR;
+
+        $zipDirectory = pathinfo($pathToZip, PATHINFO_DIRNAME) . DIRECTORY_SEPARATOR;
+
+        if (Str::startsWith($fileDirectory, $zipDirectory)) {
+            return str_replace($zipDirectory, '', $pathToFile);
+        }
 
         if ($relativePath && $relativePath != DIRECTORY_SEPARATOR && Str::startsWith($fileDirectory, $relativePath)) {
             return str_replace($relativePath, '', $pathToFile);


### PR DESCRIPTION
Avoid full path on db dumps

Revert bug added on #1366 (Sorry, my mistake)
Closes #1377

Put `db-dump` directory at the top level