### PR TITLE
Fix discord notification message not using defined avatar url

### DIFF
--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -114,7 +114,7 @@ class DiscordMessage
     {
         return [
             'username' => $this->username ?? 'Laravel Backup',
-            'avatar_url' => '',
+            'avatar_url' => $this->avatarUrl,
             'embeds' => [
                 [
                     'title' => $this->title,


### PR DESCRIPTION
Just a heads up, I didn't test if the avatar is actually missing. I just noticed that `$this->avatarUrl` isn't actually used in the `toArray()` method or anywhere else. So it seems like a custom avatar won't work.