### PR TITLE
Fix legacy backup config compatibility

### DIFF
--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -19,7 +19,7 @@ class ListCommand extends BaseCommand
 
     public function handle()
     {
-        $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
+        $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups', config('backup.monitorBackups')));
 
         $this->displayOverview($statuses)->displayFailures($statuses);
     }

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -18,7 +18,7 @@ class MonitorCommand extends BaseCommand
     {
         $hasError = false;
 
-        $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
+        $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups', config('backup.monitorBackups')));
 
         foreach ($statuses as $backupDestinationStatus) {
             $diskName = $backupDestinationStatus->backupDestination()->diskName();

--- a/tests/Commands/MonitorCommandTest.php
+++ b/tests/Commands/MonitorCommandTest.php
@@ -4,18 +4,8 @@ namespace Spatie\Backup\Tests\Commands;
 
 use Spatie\Backup\Tests\TestCase;
 
-class ListCommandTest extends TestCase
+class MonitorCommandTest extends TestCase
 {
-    /** @test */
-    public function it_can_run_the_list_command()
-    {
-        config()->set('backup.backup.destination.disks', [
-            'local',
-        ]);
-
-        $this->artisan('backup:list')->assertExitCode(0);
-    }
-
     /** @test */
     function it_falls_back_to_the_old_config_key_gracefully()
     {
@@ -27,6 +17,6 @@ class ListCommandTest extends TestCase
 
         config(['backup' => $config_values]);
 
-        $this->artisan('backup:list')->assertExitCode(0);
+        $this->artisan('backup:monitor')->assertExitCode(0);
     }
 }


### PR DESCRIPTION
Provides support for a problem I encountered in production where I used the schedule:list command on the console and wondered why it shows an unhealthy backup. I noticed that the disk configured was called local but mine was something else.

After investigating, I discovered that my config file used monitorBackups instead of monitor_backups. 

It seems that the config key was changed some time ago but I was unaware so I figure there might be others affected and thus, I created this pull request to help maintain backwards compatibility with those installations. 