### PR TITLE
Warns the user about old-style config files for backup:list and backup:monitor commands

### DIFF
--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -19,6 +19,10 @@ class ListCommand extends BaseCommand
 
     public function handle()
     {
+        if (config()->has('backup.monitorBackups')) {
+            $this->warn("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
+        }
+
         $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
 
         $this->displayOverview($statuses)->displayFailures($statuses);

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -16,6 +16,10 @@ class MonitorCommand extends BaseCommand
 
     public function handle()
     {
+        if (config()->has('backup.monitorBackups')) {
+            $this->warn("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
+        }
+
         $hasError = false;
 
         $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));

--- a/tests/Commands/ListCommandTest.php
+++ b/tests/Commands/ListCommandTest.php
@@ -25,7 +25,7 @@ class ListCommandTest extends TestCase
         config(['backup.monitorBackups' => config('backup.monitor_backups')]);
 
         $this->artisan('backup:list')
-            ->expectsOutputToContain("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
+            ->expectsOutput("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
 
     }
 }

--- a/tests/Commands/MonitorCommandTest.php
+++ b/tests/Commands/MonitorCommandTest.php
@@ -15,7 +15,7 @@ class MonitorCommandTest extends TestCase
         config(['backup.monitorBackups' => config('backup.monitor_backups')]);
 
         $this->artisan('backup:monitor')
-            ->expectsOutputToContain("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
+            ->expectsOutput("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
 
     }
 }

--- a/tests/Commands/MonitorCommandTest.php
+++ b/tests/Commands/MonitorCommandTest.php
@@ -4,27 +4,17 @@ namespace Spatie\Backup\Tests\Commands;
 
 use Spatie\Backup\Tests\TestCase;
 
-class ListCommandTest extends TestCase
+class MonitorCommandTest extends TestCase
 {
-    /** @test */
-    public function it_can_run_the_list_command()
-    {
-        config()->set('backup.backup.destination.disks', [
-            'local',
-        ]);
-
-        $this->artisan('backup:list')->assertExitCode(0);
-    }
-
     /** @test */
     function it_warns_the_user_about_the_old_style_config_keys()
     {
-        $this->artisan('backup:list')
+        $this->artisan('backup:monitor')
             ->assertSuccessful();
 
         config(['backup.monitorBackups' => config('backup.monitor_backups')]);
 
-        $this->artisan('backup:list')
+        $this->artisan('backup:monitor')
             ->expectsOutputToContain("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
 
     }


### PR DESCRIPTION
Related to PR #1494 

Since that approach won't work as mentioned in my [comment ](https://github.com/spatie/laravel-backup/pull/1494#issuecomment-1055326350), this approach warns the user instead to ensure that his config key uses the snake_case format instead of camelCase.