### PR TITLE
Use non-recursive files() method to test if destination is reachable

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -137,7 +137,7 @@ class BackupDestination
         }
 
         try {
-            $this->disk->allFiles($this->backupName);
+            $this->disk->files($this->backupName);
 
             return true;
         } catch (Exception $exception) {


### PR DESCRIPTION
The `allFiles()` method is recursive, and given that `isReachable` just tests if the destination is available and does not use the result of the method call, it seems unecessary to fetch recursively.

This PR swaps to the non-recursive `files()` method to do less work to determine the same answer.