### PR TITLE
Bug/1528 year week combo

### DIFF
--- a/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
+++ b/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
@@ -26,7 +26,7 @@ class DefaultStrategy extends CleanupStrategy
         });
 
         $backupsPerPeriod['daily'] = $this->groupByDateFormat($backupsPerPeriod['daily'], 'Ymd');
-        $backupsPerPeriod['weekly'] = $this->groupByDateIsoFormat($backupsPerPeriod['weekly'], 'YW');
+        $backupsPerPeriod['weekly'] = $this->groupByDateIsoFormat($backupsPerPeriod['weekly'], 'GW');
         $backupsPerPeriod['monthly'] = $this->groupByDateFormat($backupsPerPeriod['monthly'], 'Ym');
         $backupsPerPeriod['yearly'] = $this->groupByDateFormat($backupsPerPeriod['yearly'], 'Y');
 

--- a/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
+++ b/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
@@ -26,7 +26,7 @@ class DefaultStrategy extends CleanupStrategy
         });
 
         $backupsPerPeriod['daily'] = $this->groupByDateFormat($backupsPerPeriod['daily'], 'Ymd');
-        $backupsPerPeriod['weekly'] = $this->groupByDateFormat($backupsPerPeriod['weekly'], 'YW');
+        $backupsPerPeriod['weekly'] = $this->groupByDateIsoFormat($backupsPerPeriod['weekly'], 'YW');
         $backupsPerPeriod['monthly'] = $this->groupByDateFormat($backupsPerPeriod['monthly'], 'Ym');
         $backupsPerPeriod['yearly'] = $this->groupByDateFormat($backupsPerPeriod['yearly'], 'Y');
 
@@ -72,6 +72,11 @@ class DefaultStrategy extends CleanupStrategy
     protected function groupByDateFormat(Collection $backups, string $dateFormat): Collection
     {
         return $backups->groupBy(fn (Backup $backup) => $backup->date()->format($dateFormat));
+    }
+
+    protected function groupByDateIsoFormat(Collection $backups, string $dateFormat): Collection
+    {
+        return $backups->groupBy(fn (Backup $backup) => $backup->date()->isoFormat($dateFormat));
     }
 
     protected function removeBackupsForAllPeriodsExceptOne(Collection $backupsPerPeriod)


### PR DESCRIPTION
I only found `YW` be used once in the codebase, when deleting old backups.
Also,`formatLocalized()` is deprecated, `isoFormat()`is suggested as alternative.

Following the examples in #1528, `GW` gave the same result as the `%G%V` suggestion.
```php
Carbon::parse('2022-01-01')->formatLocalized('%G%V'); // 202152
Carbon::parse('2022-01-01')->isoFormat('GW'); // 202152
```

Closes #1528