### PR TITLE
Add a note about scenarios where backups could be lost unexpectedly

### DIFF
--- a/docs/cleaning-up-old-backups/overview.md
+++ b/docs/cleaning-up-old-backups/overview.md
@@ -80,6 +80,12 @@ older than those covered by rule #2
 
 Of course the numbers used in the default configuration can be adjusted to suit your own needs.
 
+> It is worth noting that the date of a backup is determined by the last modified date of the file. This can potentially mean unexpected backup deletions occur in the following scenarios:
+> - You move your backups to a new storage provider
+> - You restore a previously deleted backup, if the storage provider has file versioning capability
+> 
+> The solution would be to create your own strategy that does not use the last modified date of the file, but instead extracts the date from the file name
+
 ## Creating your own strategy
 
 If you're requirements are not covered by the `DefaultStrategy`, you can create your own custom strategy. 


### PR DESCRIPTION
I have been using this package successfully for over 7 years, but i've had an issue for the last year that has happened in two different codebases. Older backups were being deleted that didn't respect the config choices.

I (incorrectly) always assumed the backup date was determined from the file name, but this is not the case and explains why the backups were being deleted in these scenarios:

1. I moved the backups from DO to GCP and naturally all the timestamps were refreshed when I uploaded them. After `keep_all_backups_for_days`, all older backups would be wiped except one.
2. On another project (with versioning applied in the GCP bucket), after a while it became apparent that our config choices were not suitable and I wanted to increase the amount of monthly and yearly backups. So I started restoring the older deleted backups, which gave them a last modified date of now. Similarly, after `keep_all_backups_for_days` all but one would be deleted.

I believe that i'll need to write a custom strategy because there is no way I can change the last modified dates of these files to something in the past .

This PR puts a warning in the documentation to highlight this aspect, because I have been chasing this for a long time and have only just figured it out! (and if I didn't have versioning enabled, they'd be gone forever)