### PR TITLE
Use empty string for Discord defaults

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -191,9 +191,15 @@ return [
         'discord' => [
             'webhook_url' => '',
 
-            'username' => null,
+            /*
+             * If this is an empty string, the name field on the webhook will be used.
+             */
+            'username' => '',
 
-            'avatar_url' => null,
+            /*
+             * If this is an empty string, the avatar on the webhook will be used.
+             */
+            'avatar_url' => '',
         ],
     ],
 


### PR DESCRIPTION
Using `null` as the defaults didn't work when just entering the webhook URL. Most of the time, you will make a webhook for each notification and set name/avatar there.

This is with it being `null`:
```
Spatie\Backup\Notifications\Channels\Discord\DiscordMessage::from(): Argument #1 ($username) must be of type string, null given
```