### PR TITLE
Interrupt backup from event listeners

### DIFF
--- a/docs/advanced-usage/adding-extra-files-to-a-backup.md
+++ b/docs/advanced-usage/adding-extra-files-to-a-backup.md
@@ -14,26 +14,36 @@ Right after the manifest is created and **before** the zip file is created the `
 namespace Spatie\Backup\Events;
 
 use Spatie\Backup\Tasks\Backup\Manifest;
+use Spatie\Backup\Tasks\Backup\BackupJobStepStatus;
 
 class BackupManifestWasCreated
 {
     /** @var \Spatie\Backup\Tasks\Backup\Manifest */
     public $manifest;
+    /** @var \Spatie\Backup\Tasks\Backup\BackupJobStepStatus */
+    public $backupJobStepStatus;
 
-    public function __construct(Manifest $manifest)
+    public function __construct(Manifest $manifest, BackupJobStepStatus $backupJobStepStatus)
     {
         $this->manifest = $manifest;
+        $this->backupJobStepStatus = $backupJobStepStatus;
     }
 }
 
 ```
 
 You can use that event to add extra files to the manifest as in the example below where the extra files are passed as an array to the addFiles() method.
+You can also cause the interruption of the backup with the interruptBackupBecauseOfError() method.
 
 ```php
 use Spatie\Backup\Events\BackupManifestWasCreated;
 
 Event::listen(BackupManifestWasCreated::class, function (BackupManifestWasCreated $event) {
    $event->manifest->addFiles([$path1, $path2, ...]);
+
+   if ($anErrorOccured)
+   {
+    $event->backupJobStepStatus->interruptBackupBecauseOfError('Error while adding files to the manifest ...');
+   }
 });
 ```

--- a/docs/taking-backups/events.md
+++ b/docs/taking-backups/events.md
@@ -32,7 +32,9 @@ It has two public properties:
 
 Internally the package will build up a manifest of files. This manifest contains the dumps of the databases and any files that are selected for backup. All the files in the manifest will be zipped.
 
-It has one public property `$manifest` which is an instance of `Spatie\Backup\Tasks\Backup\Manifest`
+It has two public properties:
+- `$manifest` which is an instance of `Spatie\Backup\Tasks\Backup\Manifest`
+- `$backupJobStepStatus` which is an instance of `Spatie\Backup\Tasks\Backup\BackupJobStepStatus`
 
 ## BackupZipWasCreated
 
@@ -40,7 +42,9 @@ It has one public property `$manifest` which is an instance of `Spatie\Backup\Ta
 
 This event will be fired right after the zipfile - containing the dumps of the databases and any files that were selected for backup - is created, and before that zip will get copied over to the backup destination(s). You can use this event to do last minute manipulations on the created zip file.
 
-It has one public property `$pathToZip` which contains a path to the created zipfile.
+It has two public properties:
+- `$pathToZip` which contains a path to the created zipfile
+- `$backupJobStepStatus` which is an instance of `Spatie\Backup\Tasks\Backup\BackupJobStepStatus`
 
 ## DumpingDatabase
 
@@ -48,4 +52,6 @@ It has one public property `$pathToZip` which contains a path to the created zip
 
 This event will be fired before dumping the databases. You can use this event to do last minute manipulations on database dumper.
 
-It has one public property `$dbDumper` which is an instance of a [dumper driver](https://github.com/spatie/db-dumper).
+It has two public properties:
+- `$dbDumper` which is an instance of a [dumper driver](https://github.com/spatie/db-dumper)
+- `$backupJobStepStatus` which is an instance of `Spatie\Backup\Tasks\Backup\BackupJobStepStatus`

--- a/src/Events/BackupManifestWasCreated.php
+++ b/src/Events/BackupManifestWasCreated.php
@@ -3,11 +3,13 @@
 namespace Spatie\Backup\Events;
 
 use Spatie\Backup\Tasks\Backup\Manifest;
+use Spatie\Backup\Tasks\Backup\BackupJobStepStatus;
 
 class BackupManifestWasCreated
 {
     public function __construct(
         public Manifest $manifest,
+        public BackupJobStepStatus $backupJobStepStatus,
     ) {
     }
 }

--- a/src/Events/BackupZipWasCreated.php
+++ b/src/Events/BackupZipWasCreated.php
@@ -2,10 +2,13 @@
 
 namespace Spatie\Backup\Events;
 
+use Spatie\Backup\Tasks\Backup\BackupJobStepStatus;
+
 class BackupZipWasCreated
 {
     public function __construct(
         public string $pathToZip,
+        public BackupJobStepStatus $backupJobStepStatus,
     ) {
     }
 }

--- a/src/Events/DumpingDatabase.php
+++ b/src/Events/DumpingDatabase.php
@@ -4,10 +4,13 @@ namespace Spatie\Backup\Events;
 
 use Spatie\DbDumper\DbDumper;
 
+use Spatie\Backup\Tasks\Backup\BackupJobStepStatus;
+
 class DumpingDatabase
 {
     public function __construct(
-        public DbDumper $dbDumper
+        public DbDumper $dbDumper,
+        public BackupJobStepStatus $backupJobStepStatus,
     ) {
     }
 }

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -199,7 +199,7 @@ class BackupJob
 
         if (! $stepStatus->isSuccess())
         {
-            throw new Exception("Interrupted after manifest creation: " . $stepStatus->errorMessagesAsString());
+            throw new Exception("An error occured during the manifest creation: " . $stepStatus->errorMessagesAsString());
         }
 
         return $manifest;
@@ -244,7 +244,7 @@ class BackupJob
 
         if (! $stepStatus->isSuccess())
         {
-            throw new Exception("Interrupted after zip creation: " . $stepStatus->errorMessagesAsString());
+            throw new Exception("An error occured during the zip creation: " . $stepStatus->errorMessagesAsString());
         }
 
         return $pathToZip;
@@ -289,7 +289,7 @@ class BackupJob
 
                 if (! $stepStatus->isSuccess())
                 {
-                    throw new Exception("Interrupted before database dump: " . $stepStatus->errorMessagesAsString());
+                    throw new Exception("An error occured before the database dump: " . $stepStatus->errorMessagesAsString());
                 }
 
                 $dbDumper->dumpToFile($temporaryFilePath);

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -199,7 +199,7 @@ class BackupJob
 
         if (! $stepStatus->isSuccess())
         {
-            throw new Exception("Interrupted after manifest creation: " + $stepStatus->errorMessagesAsString());
+            throw new Exception("Interrupted after manifest creation: " . $stepStatus->errorMessagesAsString());
         }
 
         return $manifest;
@@ -244,7 +244,7 @@ class BackupJob
 
         if (! $stepStatus->isSuccess())
         {
-            throw new Exception("Interrupted after zip creation: " + $stepStatus->errorMessagesAsString());
+            throw new Exception("Interrupted after zip creation: " . $stepStatus->errorMessagesAsString());
         }
 
         return $pathToZip;
@@ -289,7 +289,7 @@ class BackupJob
 
                 if (! $stepStatus->isSuccess())
                 {
-                    throw new Exception("Interrupted before database dump: " + $stepStatus->errorMessagesAsString());
+                    throw new Exception("Interrupted before database dump: " . $stepStatus->errorMessagesAsString());
                 }
 
                 $dbDumper->dumpToFile($temporaryFilePath);

--- a/src/Tasks/Backup/BackupJobStepStatus.php
+++ b/src/Tasks/Backup/BackupJobStepStatus.php
@@ -27,7 +27,7 @@ class BackupJobStepStatus
 
     public function errorMessagesAsString(): string
     {
-        if (count($this->errorMessages < 1))
+        if (count($this->errorMessages) < 1)
         {
             return '';
         }

--- a/src/Tasks/Backup/BackupJobStepStatus.php
+++ b/src/Tasks/Backup/BackupJobStepStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\Backup\Tasks\Backup;
+
+class BackupJobStepStatus
+{
+    protected bool $success = true;
+
+    protected array $errorMessages = [];
+
+    public interruptBackupBecauseOfError($errorMessage): void
+    {
+        $this->success = false;
+
+        $this->errorMessages[] = $errorMessage;
+    }
+
+    public isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public errorMessages(): array
+    {
+        return $this->errorMessages;
+    }
+
+    public errorMessagesAsString(): string
+    {
+        if (count($this->errorMessages < 1))
+        {
+            return '';
+        }
+
+        return implode(', ', $this->errorMessages);
+    }
+}

--- a/src/Tasks/Backup/BackupJobStepStatus.php
+++ b/src/Tasks/Backup/BackupJobStepStatus.php
@@ -8,24 +8,24 @@ class BackupJobStepStatus
 
     protected array $errorMessages = [];
 
-    public interruptBackupBecauseOfError($errorMessage): void
+    public function interruptBackupBecauseOfError($errorMessage): void
     {
         $this->success = false;
 
         $this->errorMessages[] = $errorMessage;
     }
 
-    public isSuccess(): bool
+    public function isSuccess(): bool
     {
         return $this->success;
     }
 
-    public errorMessages(): array
+    public function errorMessages(): array
     {
         return $this->errorMessages;
     }
 
-    public errorMessagesAsString(): string
+    public function errorMessagesAsString(): string
     {
         if (count($this->errorMessages < 1))
         {


### PR DESCRIPTION
This Pull Request is about giving the ability to interrupt the backup from the listeners of the following events:
* `DumpingDatabase`
* `BackupManifestWasCreated`
* `BackupZipWasCreated`

Those events can be used to execute last-minute processes e.g. files can be added to the backup with the BackupManifestWasCreated listener. These processes could generate errors, making the backup invalid.

Thanks to this PR, a `BackupJobStepStatus` object is added to those 3 events and it comes with the `interruptBackupBecauseOfError` method which will cause the interruption of the backup if called.

The previous situation was that any error occuring in one of the handlers of `BackupManifestWasCreated` or `BackupZipWasCreated` (when notifications were enabled for the latter) were ignored and the backup was continuing anyway, and was eventually marked as successful.
It is to be noted that exceptions thrown in the handler of `DumpingDatabase` would have caused the backup to be interrupted, but for the sake of coherence I've added the same interruption mechanism into it.

This PR is linked to this discussion: https://github.com/spatie/laravel-backup/discussions/1550