### PR TITLE
Improve output messages for backup:monitor command

### DIFF
--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -25,14 +25,15 @@ class MonitorCommand extends BaseCommand
         $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
 
         foreach ($statuses as $backupDestinationStatus) {
+            $backupName = $backupDestinationStatus->backupDestination()->backupName();
             $diskName = $backupDestinationStatus->backupDestination()->diskName();
 
             if ($backupDestinationStatus->isHealthy()) {
-                $this->info("The backups on {$diskName} are considered healthy.");
+                $this->info("The {$backupName} backup on the {$diskName} disk is considered healthy.");
                 event(new HealthyBackupWasFound($backupDestinationStatus));
             } else {
                 $hasError = true;
-                $this->error("The backups on {$diskName} are considered unhealthy!");
+                $this->error("The {$backupName} backup on the {$diskName} disk is considered unhealthy!");
                 event(new UnhealthyBackupWasFound($backupDestinationStatus));
             }
         }

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -29,11 +29,11 @@ class MonitorCommand extends BaseCommand
             $diskName = $backupDestinationStatus->backupDestination()->diskName();
 
             if ($backupDestinationStatus->isHealthy()) {
-                $this->info("The {$backupName} backup on the {$diskName} disk is considered healthy.");
+                $this->info("The {$backupName} backups on the {$diskName} disk are considered healthy.");
                 event(new HealthyBackupWasFound($backupDestinationStatus));
             } else {
                 $hasError = true;
-                $this->error("The {$backupName} backup on the {$diskName} disk is considered unhealthy!");
+                $this->error("The {$backupName} backups on the {$diskName} disk are considered unhealthy!");
                 event(new UnhealthyBackupWasFound($backupDestinationStatus));
             }
         }


### PR DESCRIPTION
The output messages for this command are missing the name of the backup. This PR proposes to fix that. So instead of getting output like this:

```
The backups on s3 are considered healthy.
The backups on s3 are considered healthy.
The backups on r2 are considered healthy.
The backups on r2 are considered healthy.
```

You would instead get this:

```
The Project One backups on the s3 disk are considered healthy.
The Project Two backups on the s3 disk are considered healthy.
The Project Three backups on the r2 disk are considered healthy.
The Project Four backups on the r2 disk are considered healthy.
```