### PR TITLE
fix default Discord username

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -192,14 +192,15 @@ return [
             'webhook_url' => '',
 
             /*
-             * If this is an empty string, the name field on the webhook will be used.
+             * If this is null or an empty string, "Laravel Backup" will be used.
+             * Must be between 1 and 80 in length.
              */
-            'username' => '',
+            'username' => null,
 
             /*
-             * If this is an empty string, the avatar on the webhook will be used.
+             * If this is null or an empty string, the avatar on the webhook will be used.
              */
-            'avatar_url' => '',
+            'avatar_url' => null,
         ],
     ],
 

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -28,9 +28,11 @@ class DiscordMessage
 
     protected string $url = '';
 
-    public function from(string $username, string $avatarUrl = null): self
+    public function from(string $username = null, string $avatarUrl = null): self
     {
-        $this->username = $username;
+        if (! empty(trim($username))) {
+            $this->username = $username;
+        }
 
         if (! is_null($avatarUrl)) {
             $this->avatarUrl = $avatarUrl;
@@ -111,7 +113,7 @@ class DiscordMessage
     public function toArray(): array
     {
         return [
-            'username' => $this->username ?? 'Laravel Backup',
+            'username' => $this->username,
             'avatar_url' => $this->avatarUrl,
             'embeds' => [
                 [


### PR DESCRIPTION
My Discord notifications stopped working after 9th Jan 2023.

It appears it's because of the default username not being set properly. This change fixes it (username is required, default is Laravel Backup).

Discord returns this error now;
```
"{"username": ["Must be between 1 and 80 in length.", "Username cannot be \"\""]}"
// vendor/spatie/laravel-backup/src/Notifications/Channels/Discord/DiscordChannel.php:16
```

`username` can be set to null or '' so it won't break any existing configs.