### PR TITLE
Update DbDumperFactory.php

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -40,7 +40,7 @@ class DbDumperFactory
 
         $dbDumper = static::forDriver($dbConfig['driver'] ?? '')
             ->setHost(Arr::first(Arr::wrap($dbConfig['host'] ?? '')))
-            ->setDbName($dbConfig['database'])
+            ->setDbName($dbConfig['connect_via_database'] ?? $dbConfig['database'])
             ->setUserName($dbConfig['username'] ?? '')
             ->setPassword($dbConfig['password'] ?? '');
 


### PR DESCRIPTION
I am adding $dbConfig['connect_via_database'] in setDbName() as the package doesn't work with pgbouncer configuration due to the changes described here: https://github.com/laravel/framework/pull/43542

Summary: Since Laravel 9 in case you are using pgbouncer for pooling you need to add the name of the pool on a separate config variable (connect_via_database) instead of database that was used in earlier versions. 