### PR TITLE
avoid block other listeners from fired

### DIFF
--- a/src/Notifications/EventHandler.php
+++ b/src/Notifications/EventHandler.php
@@ -27,7 +27,10 @@ class EventHandler
 
             $notification = $this->determineNotification($event);
 
-            $notifiable->notify($notification);
+            rescue(
+                fn () => $notifiable->notify($notification),
+                fn () => consoleOutput()->error("Sending notification failed")
+            );
         });
     }
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -307,10 +307,7 @@ class BackupJob
     protected function sendNotification($notification): void
     {
         if ($this->sendNotifications) {
-            rescue(
-                fn () => event($notification),
-                fn () => consoleOutput()->error('Sending notification failed')
-            );
+           event($notification);
         }
     }
 

--- a/tests/TestSupport/DummyListener.php
+++ b/tests/TestSupport/DummyListener.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Backup\Tests\TestSupport;
+
+class DummyListener
+{
+    public function handle($event)
+    {
+    }
+}


### PR DESCRIPTION
Hi! This pull request moves the rescue for sending notifications from the EventHandler to avoid blocking other listeners from being fired when listening to a specific event from this package.

For instance, when writing a plugin for this package, we may listen to a particular event being fired to handle extra work, like BackupWasSuccessful. However, if the notification sending fails (for example, due to a mail error or a changed Slack API key), it may block other listeners from being fired when using the queue sync.
