### PR TITLE
Update HealthCheck.php

### DIFF
--- a/src/Tasks/Monitor/HealthCheck.php
+++ b/src/Tasks/Monitor/HealthCheck.php
@@ -8,16 +8,16 @@ use Spatie\Backup\Exceptions\InvalidHealthCheck;
 
 abstract class HealthCheck
 {
-    abstract public function checkHealth(BackupDestination $backupDestination);
+    abstract public function checkHealth(BackupDestination $backupDestination): void;
 
-    public function name(): string
+    public function getName(): string
     {
         return Str::title(class_basename($this));
     }
 
     protected function fail(string $message): void
     {
-        throw InvalidHealthCheck::because($message);
+        throw new InvalidHealthCheck($message);
     }
 
     protected function failIf(bool $condition, string $message): void
@@ -29,7 +29,7 @@ abstract class HealthCheck
 
     protected function failUnless(bool $condition, string $message): void
     {
-        if (! $condition) {
+        if (!$condition) {
             $this->fail($message);
         }
     }


### PR DESCRIPTION
Yo! I ONLY just tried to make the code more readable. I only made four changes that might be helpful. Seeing that the `checkHealth` method's return type is not defined. Noticed that the `fail` method should create a new `InvalidHealthCheck` exception object and throw it, instead of calling the `because` method. Expected it to be `void`. Also, `name` method should be renamed to `getName`, according to PSR-1 naming conventions. However, the `failUnless` method should negate the `$condition` parameter in the `if` statement to match its name.