### PR TITLE
fix: relative_path too short etc: /app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spatie/laravel-backup",
+    "name": "metafox/laravel-backup",
     "description": "A Laravel package to backup your application",
     "keywords": [
         "spatie",

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -43,7 +43,7 @@ class Zip
         }
 
         if ($relativePath && $relativePath != DIRECTORY_SEPARATOR && Str::startsWith($fileDirectory, $relativePath)) {
-            return substr($pathToFile, strlen($pathToFile));
+            return substr($pathToFile, strlen($relativePath));
         }
 
         return $pathToFile;

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -39,11 +39,11 @@ class Zip
         $zipDirectory = pathinfo($pathToZip, PATHINFO_DIRNAME) . DIRECTORY_SEPARATOR;
 
         if (Str::startsWith($fileDirectory, $zipDirectory)) {
-            return str_replace($zipDirectory, '', $pathToFile);
+            return substr($pathToFile, strlen($zipDirectory));
         }
 
         if ($relativePath && $relativePath != DIRECTORY_SEPARATOR && Str::startsWith($fileDirectory, $relativePath)) {
-            return str_replace($relativePath, '', $pathToFile);
+            return substr($pathToFile, strlen($pathToFile));
         }
 
         return $pathToFile;


### PR DESCRIPTION
fix error when run laravel-backup in docker container 

etc: relative_path=> '/app'

relative_path trims `storage/app/backup` to `storagebackup`