### PR TITLE
Add hex-blob option when dump binary data

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -253,6 +253,10 @@ class BackupJob
                 $fileName .= '.'.$dbDumper->getCompressorExtension();
             }
 
+            if (config('backup.backup.hex_blob')) {
+                $dbDumper->addExtraOption('--hex-blob');
+            }
+
             $temporaryFilePath = $this->temporaryDirectory->path('db-dumps'.DIRECTORY_SEPARATOR.$fileName);
 
             event(new DumpingDatabase($dbDumper));


### PR DESCRIPTION
@freekmurze 
I have fixed the problem of coordinate garbled.
detail ↓.
[url](https://github.com/spatie/laravel-backup/discussions/1690)