### PR TITLE
Return `Command` constants instead of integers in commands

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -16,7 +16,7 @@ class BackupCommand extends BaseCommand
 
     protected $description = 'Run the backup.';
 
-    public function handle()
+    public function handle(): int
     {
         consoleOutput()->comment($this->currentTry > 1 ? sprintf('Attempt n°%d...', $this->currentTry) : 'Starting backup...');
 
@@ -63,6 +63,8 @@ class BackupCommand extends BaseCommand
             $backupJob->run();
 
             consoleOutput()->comment('Backup completed!');
+
+            return static::SUCCESS;
         } catch (Exception $exception) {
             if ($this->shouldRetry()) {
                 if ($this->hasRetryDelay('backup')) {
@@ -82,7 +84,7 @@ class BackupCommand extends BaseCommand
                 event(new BackupHasFailed($exception));
             }
 
-            return 1;
+            return static::FAILURE;
         }
     }
 

--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -28,7 +28,7 @@ class CleanupCommand extends BaseCommand
         $this->strategy = $strategy;
     }
 
-    public function handle()
+    public function handle(): int
     {
         consoleOutput()->comment($this->currentTry > 1 ? sprintf('Attempt n°%d...', $this->currentTry) : 'Starting cleanup...');
 
@@ -46,6 +46,8 @@ class CleanupCommand extends BaseCommand
             $cleanupJob->run();
 
             consoleOutput()->comment('Cleanup completed!');
+
+            return static::SUCCESS;
         } catch (Exception $exception) {
             if ($this->shouldRetry()) {
                 if ($this->hasRetryDelay('cleanup')) {
@@ -61,7 +63,7 @@ class CleanupCommand extends BaseCommand
                 event(new CleanupHasFailed($exception));
             }
 
-            return 1;
+            return static::FAILURE;
         }
     }
 }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -17,7 +17,7 @@ class ListCommand extends BaseCommand
     /** @var string */
     protected $description = 'Display a list of all backups.';
 
-    public function handle()
+    public function handle(): int
     {
         if (config()->has('backup.monitorBackups')) {
             $this->warn("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
@@ -26,6 +26,8 @@ class ListCommand extends BaseCommand
         $statuses = BackupDestinationStatusFactory::createForMonitorConfig(config('backup.monitor_backups'));
 
         $this->displayOverview($statuses)->displayFailures($statuses);
+
+        return static::SUCCESS;
     }
 
     protected function displayOverview(Collection $backupDestinationStatuses)

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -14,7 +14,7 @@ class MonitorCommand extends BaseCommand
     /** @var string */
     protected $description = 'Monitor the health of all backups.';
 
-    public function handle()
+    public function handle(): int
     {
         if (config()->has('backup.monitorBackups')) {
             $this->warn("Warning! Your config file still uses the old monitorBackups key. Update it to monitor_backups.");
@@ -39,7 +39,9 @@ class MonitorCommand extends BaseCommand
         }
 
         if ($hasError) {
-            return 1;
+            return static::FAILURE;
         }
+
+        return static::SUCCESS;
     }
 }


### PR DESCRIPTION
## Summary
This PR converts returning integer exit codes to returning the constants defined in [Symfony Commands class](https://github.com/symfony/console/blob/6.3/Command/Command.php?plain=1#L38), making the code more expressive and easier to understand.

## Example
```php
class MyCommand extends Command
{
    public function handle(): int 
    {
        // do something that fails...

        return 1;
    }
}
```

```php
class MyCommand extends Command 
{
    public function handle(): int 
    {
        // do something that fails...

        return static::FAILURE;
    }
}
```

## Additional Changes

- Return success exit code where command is returning failure or void, ensuring the `handle` methods always returns an integer, never void.
- Declare return type `int` on `handle` methods.

## Possible Breaking Changes
If the user is extending one of the commands the package provides and are overriding the `handle` method without the `int` return type an exception will be thrown. I can remove the return type declaration added if this is a concern.
