### PR TITLE
Send one notification on backup failure

### DIFF
--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -74,6 +74,8 @@ class BackupCommand extends BaseCommand
                 return $this->handle();
             }
 
+            consoleOutput()->error("Backup failed because: {$exception->getMessage()}.");
+
             report($exception);
 
             if (! $disableNotifications) {

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -4,6 +4,7 @@ namespace Spatie\Backup\Commands;
 
 use Exception;
 use Spatie\Backup\Events\BackupHasFailed;
+use Spatie\Backup\Exceptions\BackupFailed;
 use Spatie\Backup\Exceptions\InvalidCommand;
 use Spatie\Backup\Tasks\Backup\BackupJobFactory;
 use Spatie\Backup\Traits\Retryable;
@@ -79,7 +80,10 @@ class BackupCommand extends BaseCommand
             report($exception);
 
             if (! $disableNotifications) {
-                event(new BackupHasFailed($exception));
+                event($exception instanceof BackupFailed
+                    ? new BackupHasFailed($exception->getPrevious(), $exception->backupDestination)
+                    : new BackupHasFailed($exception)
+                );
             }
 
             return 1;

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -74,7 +74,7 @@ class BackupCommand extends BaseCommand
                 return $this->handle();
             }
 
-            consoleOutput()->error("Backup failed because: {$exception->getMessage()}.");
+            consoleOutput()->error("Backup failed because: {$exception->getMessage()}." . PHP_EOL . $exception->getTraceAsString());
 
             report($exception);
 

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -74,8 +74,6 @@ class BackupCommand extends BaseCommand
                 return $this->handle();
             }
 
-            consoleOutput()->error("Backup failed because: {$exception->getMessage()}." . PHP_EOL . $exception->getTraceAsString());
-
             report($exception);
 
             if (! $disableNotifications) {

--- a/src/Events/BackupHasFailed.php
+++ b/src/Events/BackupHasFailed.php
@@ -12,7 +12,7 @@ class BackupHasFailed
         public Exception $exception,
         public ?BackupDestination $backupDestination = null,
     ) {
-        if($this->exception instanceof BackupFailed) {
+        if ($this->exception instanceof BackupFailed) {
             $this->backupDestination = $this->exception->backupDestination;
         }
     }

--- a/src/Events/BackupHasFailed.php
+++ b/src/Events/BackupHasFailed.php
@@ -12,7 +12,7 @@ class BackupHasFailed
         public Exception $exception,
         public ?BackupDestination $backupDestination = null,
     ) {
-        if($this->exception instanceof BackupFailed){
+        if($this->exception instanceof BackupFailed) {
             $this->backupDestination = $this->exception->backupDestination;
         }
     }

--- a/src/Events/BackupHasFailed.php
+++ b/src/Events/BackupHasFailed.php
@@ -4,6 +4,7 @@ namespace Spatie\Backup\Events;
 
 use Exception;
 use Spatie\Backup\BackupDestination\BackupDestination;
+use Spatie\Backup\Exceptions\BackupFailed;
 
 class BackupHasFailed
 {
@@ -11,5 +12,8 @@ class BackupHasFailed
         public Exception $exception,
         public ?BackupDestination $backupDestination = null,
     ) {
+        if($this->exception instanceof BackupFailed){
+            $this->backupDestination = $this->exception->backupDestination;
+        }
     }
 }

--- a/src/Events/BackupHasFailed.php
+++ b/src/Events/BackupHasFailed.php
@@ -4,7 +4,6 @@ namespace Spatie\Backup\Events;
 
 use Exception;
 use Spatie\Backup\BackupDestination\BackupDestination;
-use Spatie\Backup\Exceptions\BackupFailed;
 
 class BackupHasFailed
 {
@@ -12,8 +11,5 @@ class BackupHasFailed
         public Exception $exception,
         public ?BackupDestination $backupDestination = null,
     ) {
-        if ($this->exception instanceof BackupFailed) {
-            $this->backupDestination = $this->exception->backupDestination;
-        }
     }
 }

--- a/src/Exceptions/BackupFailed.php
+++ b/src/Exceptions/BackupFailed.php
@@ -5,6 +5,9 @@ namespace Spatie\Backup\Exceptions;
 use Exception;
 use Spatie\Backup\BackupDestination\BackupDestination;
 
+/**
+ * @method Exception getPrevious()
+ */
 class BackupFailed extends Exception
 {
     public ?BackupDestination $backupDestination = null;

--- a/src/Exceptions/BackupFailed.php
+++ b/src/Exceptions/BackupFailed.php
@@ -10,7 +10,7 @@ class BackupFailed extends Exception
     public ?BackupDestination $backupDestination = null;
 
     public static function from(Exception $exception): static {
-        return new static($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
+        return new static($exception->getMessage(), $exception->getCode(), $exception);
     }
 
     public function destination(BackupDestination $backupDestination): static {

--- a/src/Exceptions/BackupFailed.php
+++ b/src/Exceptions/BackupFailed.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Backup\Exceptions;
+
+use Exception;
+use Spatie\Backup\BackupDestination\BackupDestination;
+
+class BackupFailed extends Exception
+{
+    public ?BackupDestination $backupDestination = null;
+
+    public static function from(Exception $exception): static {
+        return new static($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
+    }
+
+    public function destination(BackupDestination $backupDestination): static {
+        $this->backupDestination = $backupDestination;
+
+        return $this;
+    }
+}

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -169,8 +169,6 @@ class BackupJob
 
             $this->copyToBackupDestinations($zipFile);
         } catch (Exception $exception) {
-            consoleOutput()->error("Backup failed because {$exception->getMessage()}." . PHP_EOL . $exception->getTraceAsString());
-
             $this->temporaryDirectory->delete();
 
             throw $exception;

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -12,6 +12,7 @@ use Spatie\Backup\Events\BackupManifestWasCreated;
 use Spatie\Backup\Events\BackupWasSuccessful;
 use Spatie\Backup\Events\BackupZipWasCreated;
 use Spatie\Backup\Events\DumpingDatabase;
+use Spatie\Backup\Exceptions\BackupFailed;
 use Spatie\Backup\Exceptions\InvalidBackupJob;
 use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\MongoDb;
@@ -173,7 +174,7 @@ class BackupJob
 
             $this->temporaryDirectory->delete();
 
-            throw $exception;
+            throw BackupFailed::from($exception);
         }
 
         $this->temporaryDirectory->delete();
@@ -300,7 +301,7 @@ class BackupJob
                 } catch (Exception $exception) {
                     consoleOutput()->error("Copying zip failed because: {$exception->getMessage()}.");
 
-                    throw $exception;
+                    throw BackupFailed::from($exception)->destination($backupDestination);
                 }
             });
     }

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -169,6 +169,8 @@ class BackupJob
 
             $this->copyToBackupDestinations($zipFile);
         } catch (Exception $exception) {
+            consoleOutput()->error("Backup failed because: {$exception->getMessage()}." . PHP_EOL . $exception->getTraceAsString());
+
             $this->temporaryDirectory->delete();
 
             throw $exception;

--- a/tests/Notifications/EventHandlerTest.php
+++ b/tests/Notifications/EventHandlerTest.php
@@ -51,6 +51,16 @@ it('it will send backup failed notification once with retries', function () {
     Notification::assertSentTimes(BackupHasFailedNotification::class, 1);
 });
 
+test('notification contains the original exception instead of BackupFailed', function(){
+    $exception = BackupFailed::from(new InvalidArgumentException('Something Went Wrong...'));
+
+    event(new BackupHasFailed($exception->getPrevious()));
+
+    Notification::assertSentTo(new Notifiable(), BackupHasFailedNotification::class, function ($notification) {
+        return $notification->event->exception instanceof InvalidArgumentException;
+    });
+});
+
 function fireBackupHasFailedEvent()
 {
     $exception = new Exception('Dummy exception');

--- a/tests/Notifications/EventHandlerTest.php
+++ b/tests/Notifications/EventHandlerTest.php
@@ -51,16 +51,6 @@ it('it will send backup failed notification once with retries', function () {
     Notification::assertSentTimes(BackupHasFailedNotification::class, 1);
 });
 
-test('notification contains the original exception instead of BackupFailed', function(){
-    $exception = BackupFailed::from(new InvalidArgumentException('Something Went Wrong...'));
-
-    event(new BackupHasFailed($exception->getPrevious()));
-
-    Notification::assertSentTo(new Notifiable(), BackupHasFailedNotification::class, function ($notification) {
-        return $notification->event->exception instanceof InvalidArgumentException;
-    });
-});
-
 function fireBackupHasFailedEvent()
 {
     $exception = new Exception('Dummy exception');

--- a/tests/Notifications/EventHandlerTest.php
+++ b/tests/Notifications/EventHandlerTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 use Spatie\Backup\Events\BackupHasFailed;
+use Spatie\Backup\Exceptions\BackupFailed;
 use Spatie\Backup\Notifications\Notifiable;
 use Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification as BackupHasFailedNotification;
 
@@ -33,8 +33,6 @@ it('will send a notification via the configured notification channels', function
 ]);
 
 it('it will send backup failed notification once', function () {
-    Notification::fake();
-
     config()->set('backup.backup.source.files.include', []);
     config()->set('backup.backup.source.databases', []);
 
@@ -44,8 +42,6 @@ it('it will send backup failed notification once', function () {
 });
 
 it('it will send backup failed notification once with retries', function () {
-    Notification::fake();
-
     config()->set('backup.backup.destination.disks', ['non-existing-disk']);
     config()->set('backup.backup.source.files.include', []);
     config()->set('backup.backup.source.databases', []);

--- a/tests/Notifications/EventHandlerTest.php
+++ b/tests/Notifications/EventHandlerTest.php
@@ -31,6 +31,17 @@ it('will send a notification via the configured notification channels', function
     [['mail', 'slack', 'discord']],
 ]);
 
+it('it will send backup failed notification once', function () {
+    Notification::fake();
+
+    config()->set('backup.backup.source.files.include', []);
+    config()->set('backup.backup.source.databases', []);
+
+    $this->artisan('backup:run');
+
+    Notification::assertSentTimes(BackupHasFailedNotification::class, 1);
+});
+
 function fireBackupHasFailedEvent()
 {
     $exception = new Exception('Dummy exception');

--- a/tests/Notifications/EventHandlerTest.php
+++ b/tests/Notifications/EventHandlerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 use Spatie\Backup\Events\BackupHasFailed;
@@ -38,6 +39,18 @@ it('it will send backup failed notification once', function () {
     config()->set('backup.backup.source.databases', []);
 
     $this->artisan('backup:run');
+
+    Notification::assertSentTimes(BackupHasFailedNotification::class, 1);
+});
+
+it('it will send backup failed notification once with retries', function () {
+    Notification::fake();
+
+    config()->set('backup.backup.destination.disks', ['non-existing-disk']);
+    config()->set('backup.backup.source.files.include', []);
+    config()->set('backup.backup.source.databases', []);
+
+    $this->artisan('backup:run', ['--only-files' => true, '--tries' => 5]);
 
     Notification::assertSentTimes(BackupHasFailedNotification::class, 1);
 });


### PR DESCRIPTION
Fixes #1662

## Summary
This PR addresses an issue with exception handling in [BackupJob](https://github.com/spatie/laravel-backup/blob/f4a2abc673ed61447ca748d02e9cc8be16e1c485/src/Tasks/Backup/BackupJob.php#L172C13-L172C13). 

As both the `BackupCommand` command and `BackupJob` are handling exceptions the result is both send the failure notification when they deem the process to have failed.

With these changes `BackupCommand` will exclusively handle notifying the user if a failure scenario occurs. Due to the command being able to retry itself it makes the most sense to allow **it** to determine when it considers the process to have failed. 

--------

Before these changes the `copyToBackupDestinations` method of `BackupJob` would fire the backup failed event and pass the destination as a parameter. 

https://github.com/spatie/laravel-backup/blob/f4a2abc673ed61447ca748d02e9cc8be16e1c485/src/Tasks/Backup/BackupJob.php#L300

To ensure behavior remains the same, I have added the `BackupFailed` exception which acts as a decorator with a public `$backupDestination` property which is used to set the same property in the backup failed event.

The backup destination property is set by chaining on the exception.

https://github.com/spatie/laravel-backup/blob/c394924f2016f709913e7b9894a7ed17898bdd4a/src/Tasks/Backup/BackupJob.php#L304

The notification receives the original exception for the user to debug.

https://github.com/spatie/laravel-backup/blob/dc70da6abab42f003eaa873bba792f82ffbda92a/src/Commands/BackupCommand.php#L84

## Possible Concerns

- `BackupJob` still handles success notifications and informative (including error) output to the console, we would need to completely decouple the job from the command to change this behavior, which I do not believe has any benefit to the package.
- PHPStan raised an issue with `getPrevious()` returning `Throwable|null` as `BackupHasFailed` event accepts `Exception` - to fix this an `@method` has been added to `BackupFailed`. This can be replaced with a `previous(): Exception` method if you prefer.