### PR TITLE
Move registering events to "booted" rather than "registered"

### DIFF
--- a/src/BackupServiceProvider.php
+++ b/src/BackupServiceProvider.php
@@ -36,6 +36,8 @@ class BackupServiceProvider extends PackageServiceProvider
 
     public function packageBooted()
     {
+        $this->app['events']->subscribe(EventHandler::class);
+
         if (EncryptBackupArchive::shouldEncrypt()) {
             Event::listen(BackupZipWasCreated::class, EncryptBackupArchive::class);
         }
@@ -43,8 +45,6 @@ class BackupServiceProvider extends PackageServiceProvider
 
     public function packageRegistered()
     {
-        $this->app['events']->subscribe(EventHandler::class);
-
         $this->app->singleton(ConsoleOutput::class);
 
         $this->app->bind(CleanupStrategy::class, config('backup.cleanup.strategy'));


### PR DESCRIPTION
As it is, events aren't properly registered. If you run `artisan event:list` the events won't show. But moving to booted instead, will register the events correctly.