### PR TITLE
Update `databases` key to use `DB_CONNECTION` from .env

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -80,7 +80,7 @@ return [
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper
              */
             'databases' => [
-                'mysql',
+                env('DB_CONNECTION', 'mysql'),
             ],
         ],
 


### PR DESCRIPTION
Utilizing `env('DB_CONNECTION')` enables the package to function seamlessly without requiring any adjustments to the `backup.php` configuration file. It automatically derives the database connection information from the corresponding environment variable, ensuring flexibility in database selection based on the environment.