### PR TITLE
Possibility of adding timestamp to database dump filename

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -98,6 +98,11 @@ return [
         'database_dump_compressor' => null,
 
         /*
+         * If specified, the database dumped file name will contain a timestamp (e.g.: 'Y-m-d-H-i-s').
+         */
+        'database_dump_file_timestamp_format' => null,
+
+        /*
          * The file extension used for the database dump files.
          *
          * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -256,7 +256,12 @@ class BackupJob
                     $dbName = $key . '-database';
                 }
 
-                $fileName = "{$dbType}-{$dbName}.{$this->getExtension($dbDumper)}";
+                $timeStamp = '';
+                if ($timeStampFormat = config('backup.backup.database_dump_file_timestamp_format')) {
+                    $timeStamp = '-' . Carbon::now()->format($timeStampFormat);
+                }
+
+                $fileName = "{$dbType}-{$dbName}{$timeStamp}.{$this->getExtension($dbDumper)}";
 
                 if (config('backup.backup.gzip_database_dump')) {
                     $dbDumper->useCompressor(new GzipCompressor());

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -310,6 +310,23 @@ it('renames database dump file extension when specified', function () {
     app()['db']->disconnect();
 });
 
+it('appends timestamp to database backup file name', function () {
+    config()->set('backup.backup.source.databases', ['db1']);
+    config()->set('backup.backup.database_dump_file_timestamp_format', 'Y-m-d-H-i-s');
+
+    $this->setUpDatabase(app());
+
+    $this->artisan('backup:run --only-db')->assertExitCode(0);
+
+    $this->assertExactPathExistsInZip('local', $this->expectedZipPath, 'db-dumps/sqlite-db1-database-2016-01-01-21-01-01.sql');
+
+    /*
+     * Close the database connection to unlock the sqlite file for deletion.
+     * This prevents the errors from other tests trying to delete and recreate the folder.
+     */
+    app()['db']->disconnect();
+});
+
 it('should trigger the backup failed event', function () {
     // use an invalid dbname to trigger failure
     $this->artisan('backup:run --only-db --db-name=wrongName')->assertExitCode(1);


### PR DESCRIPTION
At this moment, after unzipping several dumps, the db filename always is the same - which makes it difficult to do any comparisons between them, and we are unaware when they have been taken.

With this PR, you can choose a timestamp format (through the `'database_dump_file_timestamp_format'` config option), which will be inserted into the db dump filename and now it's clear when it was taken, eg.:
`mysql-PROJECT-2023-10-02-07-00-00.sql`

