### PR TITLE
Possibility of choosing zip compression method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-backup` will be documented in this file.
 
+## 8.3.3 - 2023-09-04
+
+### What's Changed
+
+- Added missing PT and PT/BR translations by @helderneves91 in https://github.com/spatie/laravel-backup/pull/1709
+
+**Full Changelog**: https://github.com/spatie/laravel-backup/compare/8.3.2...8.3.3
+
 ## 8.3.2 - 2023-08-30
 
 ### What's Changed

--- a/config/backup.php
+++ b/config/backup.php
@@ -106,6 +106,31 @@ return [
         'database_dump_file_extension' => '',
 
         'destination' => [
+            /*
+             * The compression algorithm to be used for creating the zip archive.
+             *
+             * If backing up only database, you may choose gzip compression for db dump and no compression at zip.
+             *
+             * Some common algorithms are listed below:
+             * ZipArchive::CM_STORE (no compression at all; set 0 as compression level)
+             * ZipArchive::CM_DEFAULT
+             * ZipArchive::CM_DEFLATE
+             * ZipArchive::CM_BZIP2
+             * ZipArchive::CM_XZ
+             *
+             * For more check https://www.php.net/manual/zip.constants.php and confirm it's supported by your system.
+             */
+            'compression_method' => ZipArchive::CM_DEFAULT,
+
+            /*
+             * The compression level corresponding to the used algorithm; an integer between 0 and 9.
+             *
+             * Check supported levels for the chosen algorithm, usually 1 means the fastest and weakest compression,
+             * while 9 the slowest and strongest one.
+             *
+             * Setting of 0 for some algorithms may switch to the strongest compression.
+             */
+            'compression_level' => 9,
 
             /*
              * The filename prefix used for the backup zip file.

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -106,9 +106,9 @@ class Zip
             }
 
             if (is_file($file)) {
-                $this->zipFile->addFile($file, ltrim($nameInZip ?: '', DIRECTORY_SEPARATOR));
+                $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR)).PHP_EOL;
 
-                if ($nameInZip && is_int($compressionMethod)) {
+                if (is_int($compressionMethod)) {
                     $this->zipFile->setCompressionName(
                         ltrim($nameInZip, DIRECTORY_SEPARATOR),
                         $compressionMethod,

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -97,6 +97,9 @@ class Zip
             $files = [$files];
         }
 
+        $compressionMethod = config('backup.backup.destination.compression_method', null);
+        $compressionLevel = config('backup.backup.destination.compression_level', 9);
+
         foreach ($files as $file) {
             if (is_dir($file)) {
                 $this->zipFile->addEmptyDir(ltrim($nameInZip ?: $file, DIRECTORY_SEPARATOR));
@@ -104,6 +107,14 @@ class Zip
 
             if (is_file($file)) {
                 $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR)).PHP_EOL;
+
+                if (is_int($compressionMethod)) {
+                    $this->zipFile->setCompressionName(
+                        ltrim($nameInZip, DIRECTORY_SEPARATOR),
+                        $compressionMethod,
+                        $compressionLevel
+                    );
+                }
             }
             $this->fileCount++;
         }

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -110,7 +110,7 @@ class Zip
 
                 if (is_int($compressionMethod)) {
                     $this->zipFile->setCompressionName(
-                        ltrim($nameInZip, DIRECTORY_SEPARATOR),
+                        ltrim($nameInZip ?: $file, DIRECTORY_SEPARATOR),
                         $compressionMethod,
                         $compressionLevel
                     );

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -106,7 +106,7 @@ class Zip
             }
 
             if (is_file($file)) {
-                $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR)).PHP_EOL;
+                $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR));
 
                 if (is_int($compressionMethod)) {
                     $this->zipFile->setCompressionName(


### PR DESCRIPTION
This PR adds possibility of choosing zip compression method and its level through these config options:
- `['destination']['compression_method']`
- `['destination']['compression_level']`

Now it's possible to select the specific compression method like `ZipArchive::CM_DEFLATE` or `ZipArchive::CM_XZ` or not use compression at all with `ZipArchive::CM_STORE`. 

It's possible to experiment and choose optimal compression for one's needs, which impacts memory/cpu usage plus time consumption and finally file size. 

In case of using only db dumps, I have decided to directly compress .sql with `GzipCompressor::class` and not compress .zip archive, which gives me less CPU usage and still acceptable file size.