### PR TITLE
Use defined config

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -80,7 +80,7 @@ return [
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper
              */
             'databases' => [
-                'mysql',
+                env('DB_CONNECTION', 'mysql'),
             ],
         ],
 
@@ -146,7 +146,7 @@ return [
              * The disk names on which the backups will be stored.
              */
             'disks' => [
-                'local',
+                env('FILESYSTEM_DISK', 'local'),
             ],
         ],
 


### PR DESCRIPTION
I added `spatie/laravel-backup` to my project and was curious why it wasn't using my default database and filesystem for the backup.

With replacing the hardcoded settings for the database and filesystem, the packe might be instantly used out of the box.