### PR TITLE
Improve strategy comments

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -286,7 +286,7 @@ return [
         'default_strategy' => [
 
             /*
-             * The number of days to keep backups, ensuring recent copies are available.
+             * The number of days for which backups must be kept.
              */
             'keep_all_backups_for_days' => 7,
 

--- a/config/backup.php
+++ b/config/backup.php
@@ -286,27 +286,33 @@ return [
         'default_strategy' => [
 
             /*
-             * The number of days for which backups must be kept.
+             * The number of days to keep backups, ensuring recent copies are available.
              */
             'keep_all_backups_for_days' => 7,
 
             /*
-             * The number of days for which daily backups must be kept.
+             * After the "keep_all_backups_for_days" period is over, the most recent backup
+             * of that day will be kept. Older backups within the same day will be removed.
+             * If you create backups only once a day, no backups will be removed yet.
              */
             'keep_daily_backups_for_days' => 16,
 
             /*
-             * The number of weeks for which one weekly backup must be kept.
+             * After the "keep_daily_backups_for_days" period is over, the most recent backup
+             * of that week will be kept. Older backups within the same week will be removed.
+             * If you create backups only once a week, no backups will be removed yet.
              */
             'keep_weekly_backups_for_weeks' => 8,
 
             /*
-             * The number of months for which one monthly backup must be kept.
+             * After the "keep_weekly_backups_for_weeks" period is over, the most recent backup
+             * of that month will be kept. Older backups within the same month will be removed.
              */
             'keep_monthly_backups_for_months' => 4,
 
             /*
-             * The number of years for which one yearly backup must be kept.
+             * After the "keep_monthly_backups_for_months" period is over, the most recent backup
+             * of that year will be kept. Older backups within the same year will be removed.
              */
             'keep_yearly_backups_for_years' => 2,
 


### PR DESCRIPTION
When reading the config the first time, I was very confused about the term "daily/weekly/monthly/yearly backup". 

The confusion arises because the terms imply a specific backup frequency but in reality, the package uses these terms to describe how long backups should be retained in each category, regardless of the actual frequency at which backups are created.

For better clarity, I would recommend to update the comments as proposed.

