### PR TITLE
Made it possible to run the backup, cleanup and monitor commands in isolated mode

### DIFF
--- a/docs/advanced-usage/isolated-mode.md
+++ b/docs/advanced-usage/isolated-mode.md
@@ -1,0 +1,22 @@
+---
+title: Isolated mode
+weight: 5
+---
+
+If your application's scheduler is running on multiple servers, you may limit the backup job to only execute on a single server.
+
+To indicate that the task should run on only one server, you may use the `--isolated` option when running the task on your server:
+
+```php
+php artisan backup:run --isolated
+```
+
+The first server to obtain the task will secure an atomic lock on the job to prevent other servers from running the same task at the same time.
+
+> To utilize this feature, your application must be using the `database`, `memcached`, `dynamodb`, or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
+
+The following commands support the `--isolated` option:
+
+- `backup:run`
+- `backup:clean`
+- `backup:monitor`

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -3,13 +3,14 @@
 namespace Spatie\Backup\Commands;
 
 use Exception;
+use Illuminate\Contracts\Console\Isolatable;
 use Spatie\Backup\Events\BackupHasFailed;
 use Spatie\Backup\Exceptions\BackupFailed;
 use Spatie\Backup\Exceptions\InvalidCommand;
 use Spatie\Backup\Tasks\Backup\BackupJobFactory;
 use Spatie\Backup\Traits\Retryable;
 
-class BackupCommand extends BaseCommand
+class BackupCommand extends BaseCommand implements Isolatable
 {
     use Retryable;
 

--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -3,6 +3,7 @@
 namespace Spatie\Backup\Commands;
 
 use Exception;
+use Illuminate\Contracts\Console\Isolatable;
 use Spatie\Backup\BackupDestination\BackupDestinationFactory;
 use Spatie\Backup\Events\CleanupHasFailed;
 use Spatie\Backup\Tasks\Cleanup\CleanupJob;

--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -9,7 +9,7 @@ use Spatie\Backup\Tasks\Cleanup\CleanupJob;
 use Spatie\Backup\Tasks\Cleanup\CleanupStrategy;
 use Spatie\Backup\Traits\Retryable;
 
-class CleanupCommand extends BaseCommand
+class CleanupCommand extends BaseCommand implements Isolatable
 {
     use Retryable;
 

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -6,7 +6,7 @@ use Spatie\Backup\Events\HealthyBackupWasFound;
 use Spatie\Backup\Events\UnhealthyBackupWasFound;
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatusFactory;
 
-class MonitorCommand extends BaseCommand
+class MonitorCommand extends BaseCommand implements Isolatable
 {
     /** @var string */
     protected $signature = 'backup:monitor';

--- a/src/Commands/MonitorCommand.php
+++ b/src/Commands/MonitorCommand.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Backup\Commands;
 
+use Illuminate\Contracts\Console\Isolatable;
 use Spatie\Backup\Events\HealthyBackupWasFound;
 use Spatie\Backup\Events\UnhealthyBackupWasFound;
 use Spatie\Backup\Tasks\Monitor\BackupDestinationStatusFactory;


### PR DESCRIPTION
I updated the `backup`, `clean` and `monitor` commands so that they can be run in isolated mode.

See https://github.com/spatie/laravel-backup/discussions/1750 for the reasoning behind this.