### PR TITLE
Fix duplicate Portuguese translations for backup dates

### DIFF
--- a/resources/lang/pt/notifications.php
+++ b/resources/lang/pt/notifications.php
@@ -40,6 +40,6 @@ return [
     'newest_backup_size' => 'Tamanho de backup mais recente',
     'number_of_backups' => 'Número de backups',
     'total_storage_used' => 'Armazenamento total usado',
-    'newest_backup_date' => 'Tamanho de backup mais recente',
-    'oldest_backup_date' => 'Tamanho de backup mais antigo',
+    'newest_backup_date' => 'Data de backup mais recente',
+    'oldest_backup_date' => 'Data de backup mais antiga',
 ];


### PR DESCRIPTION
This PR resolves an issue with duplicated Portuguese translation keys for backup date. The keys for `newest_backup_date` and `oldest_backup_date` were previously mapped to incorrect values related to backup size. 

This update ensures each key has a unique and correct translation, preventing `backupDestinationProperties()` from overwriting dates with sizes in notifications.