### PR TITLE
Add config option database_dump_file_use_connection_name

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -103,9 +103,12 @@ return [
         'database_dump_file_timestamp_format' => null,
 
         /*
-         * If specified, the database dumped file name will contain the connection name in place of the database name.
+         * The base of the dump filename, either 'database' or 'connection'
+         *
+         * If 'database' (default), the dumped filename will contain the database name.
+         * If 'connection', the dumped filename will contain the connection name.
          */
-        'database_dump_file_use_connection_name' => null,
+        'database_dump_filename_base' => 'database',
 
         /*
          * The file extension used for the database dump files.

--- a/config/backup.php
+++ b/config/backup.php
@@ -103,6 +103,11 @@ return [
         'database_dump_file_timestamp_format' => null,
 
         /*
+         * If specified, the database dumped file name will contain the connection name in place of the database name.
+         */
+        'database_dump_file_use_connection_name' => null,
+
+        /*
          * The file extension used for the database dump files.
          *
          * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -120,6 +120,19 @@ return [
         'database_dump_compressor' => null,
 
         /*
+         * If specified, the database dumped file name will contain a timestamp (e.g.: 'Y-m-d-H-i-s').
+         */
+        'database_dump_file_timestamp_format' => null,
+
+        /*
+         * The base of the dump filename, either 'database' or 'connection'
+         *
+         * If 'database' (default), the dumped filename will contain the database name.
+         * If 'connection', the dumped filename will contain the connection name.
+         */
+        'database_dump_filename_base' => 'database',
+
+        /*
          * The file extension used for the database dump files.
          *
          * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
@@ -368,6 +381,36 @@ Here's an example for MySQL:
 		]
 	],
 ```
+
+### Timestamp form of database dumps
+
+By default, database dump filenames do not contain a timestamp. If you would like to add a timestamp, you can set the timestamp format to be used in the config.
+
+For example, to save a database dump with a timestamp in the format of Y-m-d-H-i-s:
+```php
+//config/backup.php
+'backup' => [
+    ...,
+    'database_dump_file_timestamp_format' => 'Y-m-d-H-i-s',
+  ],
+```
+
+> This relates to the names of the database dump files **within** the overall backup `zip` file that is generated.
+
+### Base name of database dumps
+
+By default, database dump filenames use the database name. If you would like to name dump files with the connection name, you can set that in the config.
+
+For example, to save a database dump using the connection name in the filename:
+```php
+//config/backup.php
+'backup' => [
+    ...,
+    'database_dump_filename_base' => 'connection',
+  ],
+```
+
+> This relates to the names of the database dump files **within** the overall backup `zip` file that is generated.
 
 ### File extensions of database dumps
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -251,9 +251,12 @@ class BackupJob
 
                 $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
 
-                $dbName = $dbDumper->getDbName();
-                if ($dbDumper instanceof Sqlite) {
+                if (config('backup.backup.database_dump_file_use_connection_name')) {
+                    $dbName = $key;
+                } else if ($dbDumper instanceof Sqlite) {
                     $dbName = $key . '-database';
+                } else {
+                    $dbName = $dbDumper->getDbName();
                 }
 
                 $timeStamp = '';

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -251,7 +251,8 @@ class BackupJob
 
                 $dbType = mb_strtolower(basename(str_replace('\\', '/', get_class($dbDumper))));
 
-                if (config('backup.backup.database_dump_file_use_connection_name')) {
+
+                if (config('backup.backup.database_dump_filename_base') === 'connection') {
                     $dbName = $key;
                 } else if ($dbDumper instanceof Sqlite) {
                     $dbName = $key . '-database';

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -474,3 +474,20 @@ it('should wait before trying again when retry_delay is configured (with Sleep h
         Sleep::for(3)->seconds(),
     ]);
 });
+
+it('uses connection name in place of database name for dump filename', function () {
+    config()->set('backup.backup.source.databases', ['db1']);
+    config()->set('backup.backup.database_dump_file_use_connection_name', true);
+
+    $this->setUpDatabase(app());
+
+    $this->artisan('backup:run --only-db')->assertExitCode(0);
+
+    $this->assertExactPathExistsInZip('local', $this->expectedZipPath, 'db-dumps/sqlite-db1.sql');
+
+    /*
+     * Close the database connection to unlock the sqlite file for deletion.
+     * This prevents the errors from other tests trying to delete and recreate the folder.
+     */
+    app()['db']->disconnect();
+});

--- a/tests/Commands/BackupCommandTest.php
+++ b/tests/Commands/BackupCommandTest.php
@@ -477,7 +477,7 @@ it('should wait before trying again when retry_delay is configured (with Sleep h
 
 it('uses connection name in place of database name for dump filename', function () {
     config()->set('backup.backup.source.databases', ['db1']);
-    config()->set('backup.backup.database_dump_file_use_connection_name', true);
+    config()->set('backup.backup.database_dump_filename_base', 'connection');
 
     $this->setUpDatabase(app());
 


### PR DESCRIPTION
_Code and tests are added. Documentation update was omitted because a similar config ```database_dump_file_timestamp_format``` is not documented. I'm happy to add documentation should that be required for a merge._

This PR adds a config option at ```config('backup.backup.database_dump_file_use_connection_name')``` of type boolean, defaulting to ```null``` and thus uses the database name as it always has.

This config, if set to true, uses the connection's key from ```config('database.connections')``` in the dump file name instead of the database name


**Use Case**
I have 2 connections defined to the same database, each with different db-dumper options. I have one to dump only the schema (see my PR to [spatie/db-dumper#208](https://github.com/spatie/db-dumper/pull/208)) and a second to dump the data of the database, minus the data from large tables (large as in disk space) that I can recreate.

As the package stand now, it names the dump files for these 2 connections the same based on the database name and I only get one file in the zipped archive.

With this PR, I now have both files in the zipped archive, one for each connection.

I'm happy to make any recommended modifications or additions!




> Edited for grammar and clarity
