### PR TITLE
Added null option for unlimited backup storage size

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -319,6 +319,7 @@ return [
             /*
              * After cleaning up the backups remove the oldest backup until
              * this amount of megabytes has been reached.
+             * Set 0 for unlimited size.
              */
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],

--- a/config/backup.php
+++ b/config/backup.php
@@ -319,7 +319,7 @@ return [
             /*
              * After cleaning up the backups remove the oldest backup until
              * this amount of megabytes has been reached.
-             * Set 0 for unlimited size.
+             * Set null for unlimited size.
              */
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],

--- a/docs/cleaning-up-old-backups/overview.md
+++ b/docs/cleaning-up-old-backups/overview.md
@@ -62,7 +62,7 @@ This portion of the configuration determines which backups should be deleted.
             /*
              * After cleaning up the backups remove the oldest backup until
              * this amount of megabytes has been reached.
-             * Set 0 for unlimited size.
+             * Set null for unlimited size.
              */
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],

--- a/docs/cleaning-up-old-backups/overview.md
+++ b/docs/cleaning-up-old-backups/overview.md
@@ -62,6 +62,7 @@ This portion of the configuration determines which backups should be deleted.
             /*
              * After cleaning up the backups remove the oldest backup until
              * this amount of megabytes has been reached.
+             * Set 0 for unlimited size.
              */
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -294,7 +294,7 @@ return [
             /*
              * After cleaning up the backups remove the oldest backup until
              * this amount of megabytes has been reached.
-             * Set 0 for unlimited size.
+             * Set null for unlimited size.
              */
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -294,6 +294,7 @@ return [
             /*
              * After cleaning up the backups remove the oldest backup until
              * this amount of megabytes has been reached.
+             * Set 0 for unlimited size.
              */
             'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
         ],

--- a/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
+++ b/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
@@ -102,7 +102,7 @@ class DefaultStrategy extends CleanupStrategy
         $maximumSize = $this->config->get('backup.cleanup.default_strategy.delete_oldest_backups_when_using_more_megabytes_than')
             * 1024 * 1024;
 
-        if (($backups->size() + $this->newestBackup->sizeInBytes()) <= $maximumSize) {
+        if (!$maximumSize || ($backups->size() + $this->newestBackup->sizeInBytes()) <= $maximumSize) {
             return;
         }
         $oldest->delete();

--- a/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
+++ b/src/Tasks/Cleanup/Strategies/DefaultStrategy.php
@@ -99,10 +99,9 @@ class DefaultStrategy extends CleanupStrategy
             return;
         }
 
-        $maximumSize = $this->config->get('backup.cleanup.default_strategy.delete_oldest_backups_when_using_more_megabytes_than')
-            * 1024 * 1024;
+        $maximumSize = $this->config->get('backup.cleanup.default_strategy.delete_oldest_backups_when_using_more_megabytes_than');
 
-        if (!$maximumSize || ($backups->size() + $this->newestBackup->sizeInBytes()) <= $maximumSize) {
+        if ($maximumSize === null || ($backups->size() + $this->newestBackup->sizeInBytes()) <= $maximumSize * 1024 * 1024) {
             return;
         }
         $oldest->delete();


### PR DESCRIPTION
Hi,

I've added unlimited storage option for backups. We had a situation where we wanted to keep our backups for 30 days (backup command is run every hour) and it's a fairly large databse which grows each day so it's a little hard to determine max limit for storage and it feels kinda wrong to set it to some very very big number.

Thx!