### PR TITLE
Update documentation internal links

### DIFF
--- a/docs/advanced-usage/backing-up-a-non-laravel-application.md
+++ b/docs/advanced-usage/backing-up-a-non-laravel-application.md
@@ -5,7 +5,7 @@ weight: 2
 
 This package is tailor-made for use inside Laravel applications. But with a little bit of good will you can use it to backup non-Laravel applications as well.
 
-To do so install Laravel on the same server where your non-Laravel application runs. In the Laravel app you'll have to install this package using the [installation instructions](/laravel-backup/v8/installation-and-setup). In the `app/config/backup.php`configuration file specify the paths of the non-laravel application you wish to backup in the `backup.source.files.include` key.
+To do so install Laravel on the same server where your non-Laravel application runs. In the Laravel app you'll have to install this package using the [installation instructions](/docs/laravel-backup/v8/installation-and-setup). In the `app/config/backup.php`configuration file specify the paths of the non-laravel application you wish to backup in the `backup.source.files.include` key.
 
 Do not forget to configure the database as well. In `app/config/databases.php` put the credentials of the database used by the non-Laravel application.
 

--- a/docs/cleaning-up-old-backups/overview.md
+++ b/docs/cleaning-up-old-backups/overview.md
@@ -109,4 +109,4 @@ Don't forget to specify the full classname of your custom strategy in the `clean
 
 ## Get notifications when a cleanup goes wrong
 
-You can receive a notification when a cleanup goes wrong. Read the section on  [notifications](/laravel-backup/v8/sending-notifications/overview) for more info.
+You can receive a notification when a cleanup goes wrong. Read the section on  [notifications](/docs/laravel-backup/v8/sending-notifications/overview) for more info.

--- a/docs/monitoring-the-health-of-all-backups/overview.md
+++ b/docs/monitoring-the-health-of-all-backups/overview.md
@@ -11,7 +11,7 @@ We recommend setting up a separate Laravel installation to do the monitoring, pr
 
 We also recommend to use a central storage disk, like s3, for your backups when using the monitoring. You can still use monitoring for local disks but you'll have to add the monitoring to the app which runs the backups.
 
-To install the monitor follow the regular [installation instructions](/laravel-backup/v8/installation-and-setup).
+To install the monitor follow the regular [installation instructions](/docs/laravel-backup/v8/installation-and-setup).
 Instead of scheduling the `backup:run` and `backup:clean` commands, you should schedule the monitor command.
 
 ```php
@@ -70,7 +70,7 @@ the application that is being backed up.
 ## Get notifications of (un)healthy backups
 
 You can receive notifications when the monitor finds an (un)healthy backup. 
-Read the section on [notifications](/laravel-backup/v8/sending-notifications/overview) to learn more.
+Read the section on [notifications](/docs/laravel-backup/v8/sending-notifications/overview) to learn more.
 
 ## Checking all backups
 

--- a/docs/taking-backups/overview.md
+++ b/docs/taking-backups/overview.md
@@ -151,4 +151,4 @@ If something goes wrong copying the zip file to one filesystem, the package will
 ## Get notifications when a backup goes wrong
 
 You can receive a notification when a backup goes wrong. Read
-the section on [notifications](/laravel-backup/v8/sending-notifications/overview) to find out more.
+the section on [notifications](/docs/laravel-backup/v8/sending-notifications/overview) to find out more.


### PR DESCRIPTION
The internal links in the documentation have been corrected to ensure accuracy. Previously, the links in the 'notifications', 'installation instructions', and 'installation and setup' sections went to "/laravel-backup/v8/..." but have now been updated to "/docs/laravel-backup/v8/..."