### PR TITLE
Made ext-pcntl optional, as it was in v8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
         "spatie/laravel-signal-aware-command": "^1.2|^2.0",
         "spatie/temporary-directory": "^2.0",
         "symfony/console": "^6.0|^7.0",
-        "symfony/finder": "^6.0|^7.0",
-        "ext-pcntl": "*"
+        "symfony/finder": "^6.0|^7.0"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",
+        "ext-pcntl": "*",
         "larastan/larastan": "^2.7.0",
         "laravel/slack-notification-channel": "^2.5|^3.0",
         "league/flysystem-aws-s3-v3": "^2.0|^3.0",


### PR DESCRIPTION
On V8 ext-pcntl was optional with SignalRegistry::isSupported().

https://github.com/spatie/laravel-backup/blob/ce99f8abaf4856100f12d1279e83e36f952908ac/src/Commands/BaseCommand.php#L17-L19

Previous similar PRs:

https://github.com/spatie/laravel-backup/pull/1352
https://github.com/spatie/laravel-backup/pull/1481