### PR TITLE
[9.x] `username` parameter in `from` method should be nullable

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -235,7 +235,11 @@ return [
         'discord' => [
             'webhook_url' => '',
 
-            'username' => null,
+            /*
+             * If this is an empty string, the name field will be 'Laravel Backup'.
+             * If this is set to null, the name field on the webhook will be used.
+             */
+            'username' => '',
 
             'avatar_url' => null,
         ],

--- a/config/backup.php
+++ b/config/backup.php
@@ -235,15 +235,9 @@ return [
         'discord' => [
             'webhook_url' => '',
 
-            /*
-             * If this is an empty string, the name field on the webhook will be used.
-             */
-            'username' => '',
+            'username' => null,
 
-            /*
-             * If this is an empty string, the avatar on the webhook will be used.
-             */
-            'avatar_url' => '',
+            'avatar_url' => null,
         ],
     ],
 

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -31,10 +31,12 @@ class DiscordMessage
 
     protected string $url = '';
 
-    public function from(string $username, ?string $avatarUrl = null): self
+    public function from(?string $username = null, ?string $avatarUrl = null): self
     {
-        $this->username = $username;
-
+        if (! is_null($username)) {
+            $this->username = $username;
+        }
+        
         if (! is_null($avatarUrl)) {
             $this->avatarUrl = $avatarUrl;
         }

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -36,7 +36,7 @@ class DiscordMessage
         if (! is_null($username)) {
             $this->username = $username;
         }
-        
+
         if (! is_null($avatarUrl)) {
             $this->avatarUrl = $avatarUrl;
         }
@@ -117,7 +117,7 @@ class DiscordMessage
     public function toArray(): array
     {
         return [
-            'username' => $this->username ?? 'Laravel Backup',
+            'username' => $this->username,
             'avatar_url' => $this->avatarUrl,
             'embeds' => [
                 [

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -12,7 +12,7 @@ class DiscordMessage
 
     public const COLOR_ERROR = 'e32929';
 
-    protected string $username = 'Laravel Backup';
+    protected ?string $username = null;
 
     protected ?string $avatarUrl = null;
 
@@ -34,7 +34,7 @@ class DiscordMessage
     public function from(?string $username = null, ?string $avatarUrl = null): self
     {
         if (! is_null($username)) {
-            $this->username = $username;
+            $this->username = empty($username) ? 'Laravel Backup' : $username;
         }
 
         if (! is_null($avatarUrl)) {


### PR DESCRIPTION
Based on issue #1815, `username` parameter in `from` method should be nullable in `DiscordMessage.php` on line `13` :

`src/Notifications/Channels/Discord/DiscordMessage.php` 

```php
 protected string $username = 'Laravel Backup';
 
 ...
 public function from(string $username, string $avatarUrl = null): self
 {
         $this->username = $username;
...
```