### PR TITLE
[8.x] `username` parameter in `from` method should be nullable

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -236,14 +236,12 @@ return [
             'webhook_url' => '',
 
             /*
-             * If this is an empty string, the name field on the webhook will be used.
+             * If this is an empty string, the name field will be 'Laravel Backup'.
+             * If this is set to null, the name field on the webhook will be used.
              */
             'username' => '',
 
-            /*
-             * If this is an empty string, the avatar on the webhook will be used.
-             */
-            'avatar_url' => '',
+            'avatar_url' => null,
         ],
     ],
 

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -10,7 +10,7 @@ class DiscordMessage
     public const COLOR_WARNING = 'fD6a02';
     public const COLOR_ERROR = 'e32929';
 
-    protected string $username = 'Laravel Backup';
+    protected ?string $username = null;
 
     protected ?string $avatarUrl = null;
 
@@ -31,7 +31,7 @@ class DiscordMessage
     public function from(?string $username = null, ?string $avatarUrl = null): self
     {
         if (! is_null($username)) {
-            $this->username = $username;
+            $this->username = empty($username) ? 'Laravel Backup' : $username;
         }
 
         if (! is_null($avatarUrl)) {

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -28,9 +28,11 @@ class DiscordMessage
 
     protected string $url = '';
 
-    public function from(string $username, string $avatarUrl = null): self
+    public function from(string $username = null, string $avatarUrl = null): self
     {
-        $this->username = $username;
+        if (! is_null($username)) {
+            $this->username = $username;
+        }
 
         if (! is_null($avatarUrl)) {
             $this->avatarUrl = $avatarUrl;

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -28,7 +28,7 @@ class DiscordMessage
 
     protected string $url = '';
 
-    public function from(string $username = null, string $avatarUrl = null): self
+    public function from(?string $username = null, ?string $avatarUrl = null): self
     {
         if (! is_null($username)) {
             $this->username = $username;
@@ -113,7 +113,7 @@ class DiscordMessage
     public function toArray(): array
     {
         return [
-            'username' => $this->username ?? 'Laravel Backup',
+            'username' => $this->username,
             'avatar_url' => $this->avatarUrl,
             'embeds' => [
                 [


### PR DESCRIPTION
Based on issue #1815, `username` parameter in `from` method should be nullable in `DiscordMessage.php` on line `13` :

`src/Notifications/Channels/Discord/DiscordMessage.php`

```php
protected string $username = 'Laravel Backup';
 
...
public function from(string $username, string $avatarUrl = null): self
{
        $this->username = $username;
...
```