### PR TITLE
[9.x] Fix empty string in `backup.notifications.discord.username` to fail sending a notification

### DIFF
--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -114,8 +114,7 @@ class DiscordMessage
 
     public function toArray(): array
     {
-        return [
-            'username' => $this->username ?? 'Laravel Backup',
+        $data = [
             'avatar_url' => $this->avatarUrl,
             'embeds' => [
                 [
@@ -132,5 +131,11 @@ class DiscordMessage
                 ],
             ],
         ];
+
+        if (!empty($this->username)) {
+            $data['username'] = $this->username;
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
Fixes #1815 

This PR fixes an issue caused by using an empty string for the Discord Webhook `username` property.

According to [Discord's documentation](https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params), the `username` field is optional and when set, requires it to be between 1 and 80 characters long. This lines up with the `name` field when [creating a webhook](https://discord.com/developers/docs/resources/webhook#create-webhook).

The current implementation of the notification doesn't follow that. If the `backup.notifications.discord.username` is an empty string (which is currently the default), the notification is never sent due to a validation error. See the mentioned issue above for details.

This PR fixes these issues by only setting the username set in the config if it's not empty.

To test this, I created a server and added a webhook with the name Test McWebhook:

![image](https://github.com/user-attachments/assets/6cc0ea8e-0375-49ed-9f86-d21cf269783c)

I applied the fix to a project locally and ran it with 3 usernames in order:

- `'Laravel Backup'`
- `''`
- `'Some Other Custom Name'`

![image](https://github.com/user-attachments/assets/9a212c28-c2d3-4a57-9c35-904c0f286c3d)

As a final change, I removed the `?? 'Laravel Backup'` expression when setting the username. Since `$username` is non-nullable, that expression is never run.

