### PR TITLE
Add customize the locale to specify the backup locale for translation purposes

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -338,4 +338,10 @@ return [
         'retry_delay' => 0,
     ],
 
+    /**
+     * Here you can specify the backup locale for translation purposes.
+     * For example, if you want to use German (de) notifications even though your base app is in English.
+     * Supported languages: you can check the available languages in the `resources/lang` directory.
+     */
+    'locale' => env('BACKUP_LOCALE', 'en'),
 ];

--- a/src/Notifications/BaseNotification.php
+++ b/src/Notifications/BaseNotification.php
@@ -55,15 +55,15 @@ abstract class BaseNotification extends Notification
         $newestBackup = $backupDestination->newestBackup();
         $oldestBackup = $backupDestination->oldestBackup();
 
-        $noBackupsText = trans('backup::notifications.no_backups_info');
-        $applicationName = trans('backup::notifications.application_name');
-        $backupName = trans('backup::notifications.backup_name');
-        $disk = trans('backup::notifications.disk');
-        $newestBackupSize = trans('backup::notifications.newest_backup_size');
-        $numberOfBackups = trans('backup::notifications.number_of_backups');
-        $totalStorageUsed = trans('backup::notifications.total_storage_used');
-        $newestBackupDate = trans('backup::notifications.newest_backup_date');
-        $oldestBackupDate = trans('backup::notifications.oldest_backup_date');
+        $noBackupsText = $this->trans('backup::notifications.no_backups_info');
+        $applicationName = $this->trans('backup::notifications.application_name');
+        $backupName = $this->trans('backup::notifications.backup_name');
+        $disk = $this->trans('backup::notifications.disk');
+        $newestBackupSize = $this->trans('backup::notifications.newest_backup_size');
+        $numberOfBackups = $this->trans('backup::notifications.number_of_backups');
+        $totalStorageUsed = $this->trans('backup::notifications.total_storage_used');
+        $newestBackupDate = $this->trans('backup::notifications.newest_backup_date');
+        $oldestBackupDate = $this->trans('backup::notifications.oldest_backup_date');
 
         return collect([
             $applicationName => $this->applicationName(),
@@ -88,5 +88,10 @@ abstract class BaseNotification extends Notification
         }
 
         return null;
+    }
+
+    public function trans($key, $replace = [])
+    {
+        return trans($key, $replace, config('backup.locale'));
     }
 }

--- a/src/Notifications/Notifications/BackupHasFailedNotification.php
+++ b/src/Notifications/Notifications/BackupHasFailedNotification.php
@@ -20,12 +20,12 @@ class BackupHasFailedNotification extends BaseNotification
         $mailMessage = (new MailMessage())
             ->error()
             ->from($this->config()->notifications->mail->from->address, $this->config()->notifications->mail->from->name)
-            ->subject(trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.backup_failed_body', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))
-            ->line(trans('backup::notifications.exception_trace', ['trace' => $this->event->exception->getTraceAsString()]));
+            ->subject($this->trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.backup_failed_body', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))
+            ->line($this->trans('backup::notifications.exception_trace', ['trace' => $this->event->exception->getTraceAsString()]));
 
-        $this->backupDestinationProperties()->each(fn ($value, $name) => $mailMessage->line("{$name}: {$value}"));
+        $this->backupDestinationProperties()->each(fn($value, $name) => $mailMessage->line("{$name}: {$value}"));
 
         return $mailMessage;
     }
@@ -36,15 +36,15 @@ class BackupHasFailedNotification extends BaseNotification
             ->error()
             ->from($this->config()->notifications->slack->username, $this->config()->notifications->slack->icon)
             ->to($this->config()->notifications->slack->channel)
-            ->content(trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
+            ->content($this->trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
-                    ->title(trans('backup::notifications.exception_message_title'))
+                    ->title($this->trans('backup::notifications.exception_message_title'))
                     ->content($this->event->exception->getMessage());
             })
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
-                    ->title(trans('backup::notifications.exception_trace_title'))
+                    ->title($this->trans('backup::notifications.exception_trace_title'))
                     ->content($this->event->exception->getTraceAsString());
             })
             ->attachment(function (SlackAttachment $attachment) {
@@ -57,9 +57,9 @@ class BackupHasFailedNotification extends BaseNotification
         return (new DiscordMessage())
             ->error()
             ->from($this->config()->notifications->discord->username, $this->config()->notifications->discord->avatar_url)
-            ->title(trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
+            ->title($this->trans('backup::notifications.backup_failed_subject', ['application_name' => $this->applicationName()]))
             ->fields([
-                trans('backup::notifications.exception_message_title') => $this->event->exception->getMessage(),
+                $this->trans('backup::notifications.exception_message_title') => $this->event->exception->getMessage(),
             ]);
     }
 }

--- a/src/Notifications/Notifications/BackupWasSuccessfulNotification.php
+++ b/src/Notifications/Notifications/BackupWasSuccessfulNotification.php
@@ -19,8 +19,8 @@ class BackupWasSuccessfulNotification extends BaseNotification
     {
         $mailMessage = (new MailMessage())
             ->from($this->config()->notifications->mail->from->address, $this->config()->notifications->mail->from->name)
-            ->subject(trans('backup::notifications.backup_successful_subject', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.backup_successful_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]));
+            ->subject($this->trans('backup::notifications.backup_successful_subject', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.backup_successful_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]));
 
         $this->backupDestinationProperties()->each(function ($value, $name) use ($mailMessage) {
             $mailMessage->line("{$name}: {$value}");
@@ -35,7 +35,7 @@ class BackupWasSuccessfulNotification extends BaseNotification
             ->success()
             ->from($this->config()->notifications->slack->username, $this->config()->notifications->slack->icon)
             ->to($this->config()->notifications->slack->channel)
-            ->content(trans('backup::notifications.backup_successful_subject_title'))
+            ->content($this->trans('backup::notifications.backup_successful_subject_title'))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment->fields($this->backupDestinationProperties()->toArray());
             });
@@ -46,7 +46,7 @@ class BackupWasSuccessfulNotification extends BaseNotification
         return (new DiscordMessage())
             ->success()
             ->from($this->config()->notifications->discord->username, $this->config()->notifications->discord->avatar_url)
-            ->title(trans('backup::notifications.backup_successful_subject_title'))
+            ->title($this->trans('backup::notifications.backup_successful_subject_title'))
             ->fields($this->backupDestinationProperties()->toArray());
     }
 }

--- a/src/Notifications/Notifications/CleanupHasFailedNotification.php
+++ b/src/Notifications/Notifications/CleanupHasFailedNotification.php
@@ -20,10 +20,10 @@ class CleanupHasFailedNotification extends BaseNotification
         $mailMessage = (new MailMessage())
             ->error()
             ->from($this->config()->notifications->mail->from->address, $this->config()->notifications->mail->from->name)
-            ->subject(trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.cleanup_failed_body', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))
-            ->line(trans('backup::notifications.exception_trace', ['trace' => $this->event->exception->getTraceAsString()]));
+            ->subject($this->trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.cleanup_failed_body', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.exception_message', ['message' => $this->event->exception->getMessage()]))
+            ->line($this->trans('backup::notifications.exception_trace', ['trace' => $this->event->exception->getTraceAsString()]));
 
         $this->backupDestinationProperties()->each(function ($value, $name) use ($mailMessage) {
             $mailMessage->line("{$name}: {$value}");
@@ -38,15 +38,15 @@ class CleanupHasFailedNotification extends BaseNotification
             ->error()
             ->from($this->config()->notifications->slack->username, $this->config()->notifications->slack->icon)
             ->to($this->config()->notifications->slack->channel)
-            ->content(trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
+            ->content($this->trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()]))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
-                    ->title(trans('backup::notifications.exception_message_title'))
+                    ->title($this->trans('backup::notifications.exception_message_title'))
                     ->content($this->event->exception->getMessage());
             })
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
-                    ->title(trans('backup::notifications.exception_message_trace'))
+                    ->title($this->trans('backup::notifications.exception_message_trace'))
                     ->content($this->event->exception->getTraceAsString());
             })
             ->attachment(function (SlackAttachment $attachment) {
@@ -60,9 +60,9 @@ class CleanupHasFailedNotification extends BaseNotification
             ->error()
             ->from($this->config()->notifications->discord->username, $this->config()->notifications->discord->avatar_url)
             ->title(
-                trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()])
+                $this->trans('backup::notifications.cleanup_failed_subject', ['application_name' => $this->applicationName()])
             )->fields([
-                trans('backup::notifications.exception_message_title') => $this->event->exception->getMessage(),
+                $this->trans('backup::notifications.exception_message_title') => $this->event->exception->getMessage(),
             ]);
     }
 }

--- a/src/Notifications/Notifications/CleanupWasSuccessfulNotification.php
+++ b/src/Notifications/Notifications/CleanupWasSuccessfulNotification.php
@@ -19,8 +19,8 @@ class CleanupWasSuccessfulNotification extends BaseNotification
     {
         $mailMessage = (new MailMessage())
             ->from($this->config()->notifications->mail->from->address, $this->config()->notifications->mail->from->name)
-            ->subject(trans('backup::notifications.cleanup_successful_subject', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.cleanup_successful_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]));
+            ->subject($this->trans('backup::notifications.cleanup_successful_subject', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.cleanup_successful_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]));
 
         $this->backupDestinationProperties()->each(function ($value, $name) use ($mailMessage) {
             $mailMessage->line("{$name}: {$value}");
@@ -35,7 +35,7 @@ class CleanupWasSuccessfulNotification extends BaseNotification
             ->success()
             ->from($this->config()->notifications->slack->username, $this->config()->notifications->slack->icon)
             ->to($this->config()->notifications->slack->channel)
-            ->content(trans('backup::notifications.cleanup_successful_subject_title'))
+            ->content($this->trans('backup::notifications.cleanup_successful_subject_title'))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment->fields($this->backupDestinationProperties()->toArray());
             });
@@ -46,7 +46,7 @@ class CleanupWasSuccessfulNotification extends BaseNotification
         return (new DiscordMessage())
             ->success()
             ->from($this->config()->notifications->discord->username, $this->config()->notifications->discord->avatar_url)
-            ->title(trans('backup::notifications.cleanup_successful_subject_title'))
+            ->title($this->trans('backup::notifications.cleanup_successful_subject_title'))
             ->fields($this->backupDestinationProperties()->toArray());
     }
 }

--- a/src/Notifications/Notifications/HealthyBackupWasFoundNotification.php
+++ b/src/Notifications/Notifications/HealthyBackupWasFoundNotification.php
@@ -19,8 +19,8 @@ class HealthyBackupWasFoundNotification extends BaseNotification
     {
         $mailMessage = (new MailMessage())
             ->from($this->config()->notifications->mail->from->address, $this->config()->notifications->mail->from->name)
-            ->subject(trans('backup::notifications.healthy_backup_found_subject', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]))
-            ->line(trans('backup::notifications.healthy_backup_found_body', ['application_name' => $this->applicationName()]));
+            ->subject($this->trans('backup::notifications.healthy_backup_found_subject', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]))
+            ->line($this->trans('backup::notifications.healthy_backup_found_body', ['application_name' => $this->applicationName()]));
 
         $this->backupDestinationProperties()->each(function ($value, $name) use ($mailMessage) {
             $mailMessage->line("{$name}: {$value}");
@@ -35,7 +35,7 @@ class HealthyBackupWasFoundNotification extends BaseNotification
             ->success()
             ->from($this->config()->notifications->slack->username, $this->config()->notifications->slack->icon)
             ->to($this->config()->notifications->slack->channel)
-            ->content(trans('backup::notifications.healthy_backup_found_subject_title', ['application_name' => $this->applicationName()]))
+            ->content($this->trans('backup::notifications.healthy_backup_found_subject_title', ['application_name' => $this->applicationName()]))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment->fields($this->backupDestinationProperties()->toArray());
             });
@@ -47,7 +47,7 @@ class HealthyBackupWasFoundNotification extends BaseNotification
             ->success()
             ->from($this->config()->notifications->discord->username, $this->config()->notifications->discord->avatar_url)
             ->title(
-                trans('backup::notifications.healthy_backup_found_subject_title', [
+                $this->trans('backup::notifications.healthy_backup_found_subject_title', [
                     'application_name' => $this->applicationName(),
                 ])
             )->fields($this->backupDestinationProperties()->toArray());

--- a/src/Notifications/Notifications/UnhealthyBackupWasFoundNotification.php
+++ b/src/Notifications/Notifications/UnhealthyBackupWasFoundNotification.php
@@ -21,8 +21,8 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
         $mailMessage = (new MailMessage())
             ->error()
             ->from($this->config()->notifications->mail->from->address, $this->config()->notifications->mail->from->name)
-            ->subject(trans('backup::notifications.unhealthy_backup_found_subject', ['application_name' => $this->applicationName()]))
-            ->line(trans('backup::notifications.unhealthy_backup_found_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]))
+            ->subject($this->trans('backup::notifications.unhealthy_backup_found_subject', ['application_name' => $this->applicationName()]))
+            ->line($this->trans('backup::notifications.unhealthy_backup_found_body', ['application_name' => $this->applicationName(), 'disk_name' => $this->diskName()]))
             ->line($this->problemDescription());
 
         $this->backupDestinationProperties()->each(function ($value, $name) use ($mailMessage) {
@@ -31,9 +31,9 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
 
         if ($this->failure()->wasUnexpected()) {
             $mailMessage
-                ->line('Health check: '.$this->failure()->healthCheck()->name())
-                ->line(trans('backup::notifications.exception_message', ['message' => $this->failure()->exception()->getMessage()]))
-                ->line(trans('backup::notifications.exception_trace', ['trace' => $this->failure()->exception()->getTraceAsString()]));
+                ->line('Health check: ' . $this->failure()->healthCheck()->name())
+                ->line($this->trans('backup::notifications.exception_message', ['message' => $this->failure()->exception()->getMessage()]))
+                ->line($this->trans('backup::notifications.exception_trace', ['trace' => $this->failure()->exception()->getTraceAsString()]));
         }
 
         return $mailMessage;
@@ -45,7 +45,7 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
             ->error()
             ->from($this->config()->notifications->slack->username, $this->config()->notifications->slack->icon)
             ->to($this->config()->notifications->slack->channel)
-            ->content(trans('backup::notifications.unhealthy_backup_found_subject_title', ['application_name' => $this->applicationName(), 'problem' => $this->problemDescription()]))
+            ->content($this->trans('backup::notifications.unhealthy_backup_found_subject_title', ['application_name' => $this->applicationName(), 'problem' => $this->problemDescription()]))
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment->fields($this->backupDestinationProperties()->toArray());
             });
@@ -59,12 +59,12 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
                 })
                 ->attachment(function (SlackAttachment $attachment) {
                     $attachment
-                        ->title(trans('backup::notifications.exception_message_title'))
+                        ->title($this->trans('backup::notifications.exception_message_title'))
                         ->content($this->failure()->exception()->getMessage());
                 })
                 ->attachment(function (SlackAttachment $attachment) {
                     $attachment
-                        ->title(trans('backup::notifications.exception_trace_title'))
+                        ->title($this->trans('backup::notifications.exception_trace_title'))
                         ->content($this->failure()->exception()->getTraceAsString());
                 });
         }
@@ -78,7 +78,7 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
             ->error()
             ->from($this->config()->notifications->discord->username, $this->config()->notifications->discord->avatar_url)
             ->title(
-                trans('backup::notifications.unhealthy_backup_found_subject_title', [
+                $this->trans('backup::notifications.unhealthy_backup_found_subject_title', [
                     'application_name' => $this->applicationName(),
                     'problem' => $this->problemDescription(),
                 ])
@@ -88,7 +88,7 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
             $discordMessage
                 ->fields(['Health Check' => $this->failure()->healthCheck()->name()])
                 ->fields([
-                    trans('backup::notifications.exception_message_title') => $this->failure()->exception()->getMessage(),
+                    $this->trans('backup::notifications.exception_message_title') => $this->failure()->exception()->getMessage(),
                 ]);
         }
 
@@ -98,7 +98,7 @@ class UnhealthyBackupWasFoundNotification extends BaseNotification
     protected function problemDescription(): string
     {
         if ($this->failure()->wasUnexpected()) {
-            return trans('backup::notifications.unhealthy_backup_found_unknown');
+            return $this->trans('backup::notifications.unhealthy_backup_found_unknown');
         }
 
         return $this->failure()->exception()->getMessage();


### PR DESCRIPTION
This PR is just for create specify the backup locale for custom translation.

Here is the reason I address this PR:
- Our base application used locale ID but we want backup notifications using English.
- I have not found in this package how to customize the locale.

That's all for me Happy Coding.