### PR TITLE
[BUG] merge published config with package config

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -27,10 +27,10 @@ class Config extends Data
         $source = require dirname(__DIR__, 2).'/config/backup.php';
 
         return new self(
-            backup: BackupConfig::fromArray(array_merge($source['backup'], $data['backup'] ?? [])),
-            notifications: NotificationsConfig::fromArray(array_merge($source['notifications'], $data['notifications'] ?? [])),
+            backup: BackupConfig::fromArray(array_replace_recursive($source['backup'], $data['backup'] ?? [])),
+            notifications: NotificationsConfig::fromArray(array_replace_recursive($source['notifications'], $data['notifications'] ?? [])),
             monitoredBackups: MonitoredBackupsConfig::fromArray($data['monitor_backups'] ?? $source['monitor_backups']),
-            cleanup: CleanupConfig::fromArray(array_merge($source['cleanup'], $data['cleanup'] ?? []))
+            cleanup: CleanupConfig::fromArray(array_replace_recursive($source['cleanup'], $data['cleanup'] ?? []))
         );
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -43,14 +43,14 @@ it('merges the published config file with package config file', function () {
     $config = Config::fromArray(config('backup'));
 
     expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
-    expect($config->backup->destination->compressionMethod)->toBe(-1);
-});
+    expect($config->backup->destination->compressionMethod)->toBe(ZipArchive::CM_DEFAULT);
+})->only();
 
 it('merges the published config file with package config file and preserve published config values', function () {
-    config()->set('backup.backup.destination', ['compression_method' => 2]);
+    config()->set('backup.backup.destination', ['compression_method' => ZipArchive::CM_DEFLATE]);
 
     $config = Config::fromArray(config('backup'));
 
     expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
-    expect($config->backup->destination->compressionMethod)->toBe(2);
-});
+    expect($config->backup->destination->compressionMethod)->toBe(ZipArchive::CM_DEFLATE);
+})->only();

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -3,6 +3,7 @@
 use Spatie\Backup\Config\BackupConfig;
 use Spatie\Backup\Config\CleanupConfig;
 use Spatie\Backup\Config\Config;
+use Spatie\Backup\Config\DestinationConfig;
 use Spatie\Backup\Config\MonitoredBackupsConfig;
 use Spatie\Backup\Config\NotificationsConfig;
 
@@ -34,4 +35,22 @@ it('receives temp directory as configured from service container', function () {
     $tempDirectory = app()->make('backup-temporary-project');
 
     expect($tempDirectory->path())->toBe('/foo');
+});
+
+it('merges the published config file with package config file', function () {
+    config()->set('backup.backup.destination', []);
+
+    $config = Config::fromArray(config('backup'));
+
+    expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
+    expect($config->backup->destination->compressionMethod)->toBe(-1);
+});
+
+it('merges the published config file with package config file and preserve published config values', function () {
+    config()->set('backup.backup.destination', ['compression_method' => 2]);
+
+    $config = Config::fromArray(config('backup'));
+
+    expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
+    expect($config->backup->destination->compressionMethod)->toBe(2);
 });


### PR DESCRIPTION
There is currently a bug on the way the configs are merged. If a "nested array key" is missing on the published config file, `array_merge()` wouldn't add that key and the application will fail to properly boot the config. 

I got the following error after updating from v8 to v9 - ` Undefined array key "compression_method"`.

I dug a bit on it, and indeed my published `backup.php` config file didn't had that key, but that key is present on the package config file: https://github.com/spatie/laravel-backup/blob/fe980cee0a5d2b0773395da3446cd81a3288100a/config/backup.php#L133 so I would expect the "default package value" to be used. 

This PR changes `array_merge` to `array_replace_recursive`, so that we use the package config as the base, and replace any values from the published config file. 

I've added tests for both scenarios (without keys present in the published config file, and with keys present in the config file). 

@freekmurze any chance you can take a look at this ? 

Cheers