### PR TITLE
remove the `only()` from tests

### DIFF
--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -44,7 +44,7 @@ it('merges the published config file with package config file', function () {
 
     expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
     expect($config->backup->destination->compressionMethod)->toBe(ZipArchive::CM_DEFAULT);
-})->only();
+});
 
 it('merges the published config file with package config file and preserve published config values', function () {
     config()->set('backup.backup.destination', ['compression_method' => ZipArchive::CM_DEFLATE]);
@@ -53,4 +53,4 @@ it('merges the published config file with package config file and preserve publi
 
     expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
     expect($config->backup->destination->compressionMethod)->toBe(ZipArchive::CM_DEFLATE);
-})->only();
+});


### PR DESCRIPTION
Sorry @freekmurze I forgot to remove the `only()` while writing the tests for PR #1873 .

🙏 