### PR TITLE
account for empty array in notifications config

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -26,9 +26,11 @@ class Config extends Data
     {
         $source = require dirname(__DIR__, 2).'/config/backup.php';
 
+        $data['notifications']['notifications'] = array_replace($source['notifications']['notifications'], $data['notifications']['notifications'] ?? []);
+
         return new self(
             backup: BackupConfig::fromArray(array_replace_recursive($source['backup'], $data['backup'] ?? [])),
-            notifications: NotificationsConfig::fromArray(array_replace_recursive($source['notifications'], $data['notifications'] ?? [])),
+            notifications: NotificationsConfig::fromArray(array_merge($source['notifications'], $data['notifications'])),
             monitoredBackups: MonitoredBackupsConfig::fromArray($data['monitor_backups'] ?? $source['monitor_backups']),
             cleanup: CleanupConfig::fromArray(array_replace_recursive($source['cleanup'], $data['cleanup'] ?? []))
         );

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -54,3 +54,24 @@ it('merges the published config file with package config file and preserve publi
     expect($config->backup->destination)->toBeInstanceOf(DestinationConfig::class);
     expect($config->backup->destination->compressionMethod)->toBe(ZipArchive::CM_DEFLATE);
 });
+
+it('it ensures empty arrays on notifications are respected', function () {
+    config()->set('backup.notifications.notifications', ['Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification' => []]);
+
+    $config = Config::fromArray(config('backup'));
+    expect($config->notifications->notifications['Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification'])->toBe([]);
+});
+
+it('it ensures empty arrays on healthchecks are kept', function () {
+    config()->set('backup.monitor_backups', [
+        [
+            'name' => 'foo',
+            'disks' => ['local'],
+            'health_checks' => [],
+        ]
+    ]);
+
+    $config = Config::fromArray(config('backup'));
+
+    expect($config->monitoredBackups->monitorBackups[0]['healthChecks'])->toBe([]);
+});


### PR DESCRIPTION
reported in https://github.com/spatie/laravel-backup/issues/1879

Given how the configurations are built, `array_replace_recursive` won't allow to use an empty array as replacement. 

I am not 100% happy with this solution as it requires to treat `$notifications` array differently from other configs. So feel free to close this and revert the other PR. 

Anyway I added tests for this changes to ensure it's working as expected, I just don't like to have that "special" treatment of notifications array. 

This wouldn't be an issue if instead of an empty array, the way to disable the notification was setting it to `null/false`, but at this moment it would be a breaking change. 

@freekmurze 

