### PR TITLE
add config merger class

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Backup\Config;
 
+use Spatie\Backup\Support\ConfigMerger;
 use Spatie\Backup\Support\Data;
 
 class Config extends Data
@@ -27,10 +28,10 @@ class Config extends Data
         $source = require dirname(__DIR__, 2).'/config/backup.php';
 
         return new self(
-            backup: BackupConfig::fromArray(array_merge($source['backup'], $data['backup'] ?? [])),
-            notifications: NotificationsConfig::fromArray(array_merge($source['notifications'], $data['notifications'] ?? [])),
-            monitoredBackups: MonitoredBackupsConfig::fromArray($data['monitor_backups'] ?? $source['monitor_backups']),
-            cleanup: CleanupConfig::fromArray(array_merge($source['cleanup'], $data['cleanup'] ?? []))
+            backup: BackupConfig::fromArray(ConfigMerger::merge($data['backup'] ?? [], $source['backup'])),
+            notifications: NotificationsConfig::fromArray(ConfigMerger::merge($data['notifications'] ?? [], $source['notifications'])),
+            monitoredBackups: MonitoredBackupsConfig::fromArray(ConfigMerger::merge($data['monitor_backups'] ?? [], $source['monitor_backups'] ?? [])),
+            cleanup: CleanupConfig::fromArray(ConfigMerger::merge($data['cleanup'] ?? [], $source['cleanup']))
         );
     }
 }

--- a/src/Support/ConfigMerger.php
+++ b/src/Support/ConfigMerger.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Backup\Support;
+
+class ConfigMerger
+{
+    public static function merge(array $config, array $defaultConfig): array
+    {
+        $result = $defaultConfig;
+        foreach ($config as $key => $value) {
+            if (is_array($value)) {
+                if (empty($value)) {
+                    $result[$key] = [];
+
+                    continue;
+                }
+
+                if (isset($result[$key]) && is_array($result[$key])) {
+                    $result[$key] = self::merge($value, $result[$key]);
+
+                    continue;
+                }
+            }
+
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
This class will correctly handle merging configs. 

None of the native php functions handle the merge process of the config arrays given the current setup. 

This class ensures arrays are merged correctly and "empty" arrays are respected.

This is a super-seed of #1880 that was reverted. 👍 