### PR TITLE
NotificationMailSenderConfig - remove redundant [ 'from' ] key 

### DIFF
--- a/src/Config/NotificationMailSenderConfig.php
+++ b/src/Config/NotificationMailSenderConfig.php
@@ -15,7 +15,7 @@ class NotificationMailSenderConfig extends Data
     /** @param  array<mixed>  $data */
     public static function fromArray(array $data): self
     {
-        $address = $data['from']['address'] ?? config('mail.from.address');
+        $address = $data['address'] ?? config('mail.from.address');
 
         if ($address === null) {
             throw InvalidConfig::missingSender();
@@ -27,7 +27,7 @@ class NotificationMailSenderConfig extends Data
 
         return new self(
             address: $address,
-            name: $data['from']['name'] ?? config('mail.from.name'),
+            name: $data['name'] ?? config('mail.from.name'),
         );
     }
 }


### PR DESCRIPTION
Based on issue #1866

Since `NotificationMailSenderConfig::fromArray` is called in `NotificationMailConfig.php` on line 33 : 

```
 return new self(
      to: $data['to'],
      from: NotificationMailSenderConfig::fromArray($data['from'] ?? []),
 ); 
 ```
 
 with `$data['from']`, `from` shouldn't be reached again in `NotificationMailSenderConfig` on line 18 and 30 : 
 
 ```diff
- $address = $data['from']['address'] ?? config('mail.from.address');
+ $address = $data['address'] ?? config('mail.from.address');
...
- name: $data['from']['name'] ?? config('mail.from.name'),
+ name: $data['name'] ?? config('mail.from.name'),
```
 