### PR TITLE
Update backup.php

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -77,7 +77,7 @@ return [
              * For a complete list of available customization options, see https://github.com/spatie/db-dumper
              */
             'databases' => [
-                'mysql',
+                env('DB_CONNECTION', 'mysql'),
             ],
         ],
 


### PR DESCRIPTION
Hi Spatie folks! 🙋‍♂️

Could it be a good idea to use the `DB_CONNECTION` env var as default database connection to support not only mysql but also **pgsql** and **sqlite** by default?