### PR TITLE
DbDumperFactory: Ignore invalid ports

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -57,7 +57,9 @@ class DbDumperFactory
         }
 
         if (isset($dbConfig['port'])) {
-            $dbDumper = $dbDumper->setPort($dbConfig['port']);
+            if (is_integer($dbConfig['port'])) {
+                $dbDumper = $dbDumper->setPort($dbConfig['port']);
+            }
         }
 
         if (isset($dbConfig['dump'])) {


### PR DESCRIPTION
When an environment variable is set to blank, this is often translated to `''` rather than `null`; which leads immediately to 
```
Type error: Argument 1 passed to Spatie\DbDumper\DbDumper::setPort() must be of the type integer, string given
```

Fixes https://github.com/grokability/snipe-it/issues/14374
Fixes https://github.com/spatie/laravel-backup/issues/628

Other things to think about:

- This should warn when it ignores input; just wasn't sure about what the laravel way to do this was
- Other things that are using `isset()` but could be `!empty()`