### PR TITLE
Use MariaDb dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/notifications": "^10.10.0|^11.0|^12.0",
         "illuminate/support": "^10.10.0|^11.0|^12.0",
         "league/flysystem": "^3.0",
-        "spatie/db-dumper": "^3.7",
+        "spatie/db-dumper": "^3.8",
         "spatie/laravel-package-tools": "^1.6.2",
         "spatie/laravel-signal-aware-command": "^1.2|^2.0",
         "spatie/temporary-directory": "^2.0",

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -7,6 +7,7 @@ use Illuminate\Database\ConfigurationUrlParser;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Spatie\Backup\Exceptions\CannotCreateDbDumper;
+use Spatie\DbDumper\Databases\MariaDb;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\PostgreSql;
@@ -85,7 +86,8 @@ class DbDumperFactory
         }
 
         return match ($driver) {
-            'mysql', 'mariadb' => new MySql,
+            'mysql' => new MySql,
+            'mariadb' => new MariaDb,
             'pgsql' => new PostgreSql,
             'sqlite' => new Sqlite,
             'mongodb' => new MongoDb,

--- a/tests/DbDumperFactoryTest.php
+++ b/tests/DbDumperFactoryTest.php
@@ -2,6 +2,7 @@
 
 use Spatie\Backup\Exceptions\CannotCreateDbDumper;
 use Spatie\Backup\Tasks\Backup\DbDumperFactory;
+use Spatie\DbDumper\Databases\MariaDb;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\PostgreSql;
@@ -9,6 +10,15 @@ use Spatie\DbDumper\Databases\Sqlite;
 
 beforeEach(function () {
     config()->set('database.default', 'mysql');
+
+    config()->set('database.connections.mariadb', [
+        'driver' => 'mariadb',
+        'host' => 'localhost',
+        'port' => 3306,
+        'database' => 'myDb',
+        'username' => 'root',
+        'password' => 'myPassword',
+    ]);
 
     config()->set('database.connections.mongodb', [
         'driver' => 'mongodb',
@@ -40,8 +50,9 @@ beforeEach(function () {
     ]);
 });
 
-it('can create instances of mysql and pgsql and mongodb', function () {
+it('can create instances of mysql and mariadb and pgsql and mongodb', function () {
     expect(DbDumperFactory::createFromConnection('mysql'))->toBeInstanceOf(MySql::class);
+    expect(DbDumperFactory::createFromConnection('mariadb'))->toBeInstanceOf(MariaDb::class);
     expect(DbDumperFactory::createFromConnection('pgsql'))->toBeInstanceOf(PostgreSql::class);
     expect(DbDumperFactory::createFromConnection('mongodb'))->toBeInstanceOf(MongoDb::class);
 });


### PR DESCRIPTION
The spatie/laravel-backup package currently uses MySQL dumper for all MySQL-compatible databases, including MariaDB.

However, MariaDB has deprecated the mysqldump utility in favor of mariadb-dump as documented in their official documentation.

Recently, a dedicated MariaDB dumper was added to the spatie/db-dumper package in https://github.com/spatie/db-dumper/pull/220, which properly uses the mariadb-dump utility.

This PR updates this package to utilize the new dumper when a MariaDB connection is required.

on-behalf-of: @e-solutions-GmbH <info@esolutions.de>