### PR TITLE
Improve port check condition

### DIFF
--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -64,7 +64,7 @@ class DbDumperFactory
                     'max_range' => 65535,
                 ],
             ]) !== false) {
-                $dbDumper = $dbDumper->setPort($dbConfig['port']);
+                $dbDumper = $dbDumper->setPort((int) $dbConfig['port']);
             }
         }
 

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -61,8 +61,8 @@ class DbDumperFactory
             if (filter_var($dbConfig['port'], FILTER_VALIDATE_INT, [
                 'options' => [
                     'min_range' => 1,
-                    'max_range' => 65535
-                ]
+                    'max_range' => 65535,
+                ],
             ]) !== false) {
                 $dbDumper = $dbDumper->setPort($dbConfig['port']);
             }

--- a/src/Tasks/Backup/DbDumperFactory.php
+++ b/src/Tasks/Backup/DbDumperFactory.php
@@ -58,7 +58,12 @@ class DbDumperFactory
         }
 
         if (isset($dbConfig['port'])) {
-            if (is_int($dbConfig['port'])) {
+            if (filter_var($dbConfig['port'], FILTER_VALIDATE_INT, [
+                'options' => [
+                    'min_range' => 1,
+                    'max_range' => 65535
+                ]
+            ]) !== false) {
                 $dbDumper = $dbDumper->setPort($dbConfig['port']);
             }
         }


### PR DESCRIPTION
Condition fails for cases when port is valid number, but defined as string as well as checks for range from 1 to 65535.