### PR TITLE
Correct danish translation for "application"

### DIFF
--- a/resources/lang/da/notifications.php
+++ b/resources/lang/da/notifications.php
@@ -34,7 +34,7 @@ return [
     'unhealthy_backup_found_full' => 'Backups bruger for meget plads. Nuværende disk forbrug er :disk_usage, hvilket er mere end den tilladte grænse på :disk_limit.',
 
     'no_backups_info' => 'Der blev ikke foretaget nogen sikkerhedskopier endnu',
-    'application_name' => 'Ansøgningens navn',
+    'application_name' => 'Applikationens navn',
     'backup_name' => 'Backup navn',
     'disk' => 'Disk',
     'newest_backup_size' => 'Nyeste backup-størrelse',


### PR DESCRIPTION
While "Ansøgning" in certain contexts can refer to "application", it typically suggests formal application (e.g., "jobansøgning"). In system messages, the technical term "applikation" should be employed. 

This makes the change consistent with the rest of translations.