### PR TITLE
Include additional properties in backup notifications

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -210,6 +210,13 @@ return [
          */
         'notifiable' => \Spatie\Backup\Notifications\Notifiable::class,
 
+        /*
+         * Include additional properties to notifications, like url, version, server properties, etc...
+         */
+        'properties' => [
+            // 'Url' => env('APP_URL'),
+        ],
+
         'mail' => [
             'to' => 'your@example.com',
 

--- a/src/Notifications/BaseNotification.php
+++ b/src/Notifications/BaseNotification.php
@@ -74,6 +74,7 @@ abstract class BaseNotification extends Notification
             $totalStorageUsed => Format::humanReadableSize($backupDestination->backups()->size()),
             $newestBackupDate => $newestBackup ? $newestBackup->date()->format('Y/m/d H:i:s') : $noBackupsText,
             $oldestBackupDate => $oldestBackup ? $oldestBackup->date()->format('Y/m/d H:i:s') : $noBackupsText,
+            ...config('backup.notifications.properties', []),
         ])->filter();
     }
 


### PR DESCRIPTION
With the current notification system, the included properties are hardcoded and there is no way of including metadata or additonal infomation about the deployment.

This proposal adds a new `backup.notifications.properties` config, where you can include addiitonal key/value pairs to the notification properties, for example server url/version/deployment id/etc...

This is a non breaking change, if the config is empty, nothing changes.