### PR TITLE
fix: typo

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -56,7 +56,7 @@ return [
              * 'mysql' => [
              *       ...
              *      'dump' => [
-             *           'excludeTables' => [
+             *           'exclude_tables' => [
              *                'table_to_exclude_from_backup',
              *                'another_table_to_exclude'
              *            ]

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -89,7 +89,7 @@ return [
              * 'mysql' => [
              *       ...
              *      'dump' => [
-             *           'excludeTables' => [
+             *           'exclude_tables' => [
              *                'table_to_exclude_from_backup',
              *                'another_table_to_exclude'
              *            ]


### PR DESCRIPTION
Rename `excludeTables` to `exclude_tables` on config and doc examples as it does not work and to avoid copy paste issues