### PR TITLE
fix: resolve ZipArchive::open() return value not checked, BackupDestination::write() on exceptions, glob() returning false causes type errors

### DIFF
--- a/src/BackupDestination/BackupDestination.php
+++ b/src/BackupDestination/BackupDestination.php
@@ -68,14 +68,16 @@ class BackupDestination
 
         $handle = fopen($file, 'r+');
 
-        $this->disk->getDriver()->writeStream(
-            $destination,
-            $handle,
-            $this->getDiskOptions(),
-        );
-
-        if (is_resource($handle)) {
-            fclose($handle);
+        try {
+            $this->disk->getDriver()->writeStream(
+                $destination,
+                $handle,
+                $this->getDiskOptions(),
+            );
+        } finally {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
         }
     }
 

--- a/src/Listeners/EncryptBackupArchive.php
+++ b/src/Listeners/EncryptBackupArchive.php
@@ -3,6 +3,7 @@
 namespace Spatie\Backup\Listeners;
 
 use Spatie\Backup\Events\BackupZipWasCreated;
+use Spatie\Backup\Exceptions\BackupFailed;
 use ZipArchive;
 
 class EncryptBackupArchive
@@ -15,7 +16,11 @@ class EncryptBackupArchive
 
         $zip = new ZipArchive;
 
-        $zip->open($event->pathToZip);
+        $result = $zip->open($event->pathToZip);
+
+        if ($result !== true) {
+            throw BackupFailed::from(new \Exception("Failed to open zip file for encryption at '{$event->pathToZip}'. ZipArchive error code: {$result}"));
+        }
 
         $this->encrypt($zip);
 

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -16,7 +16,6 @@ use Spatie\Backup\Events\BackupZipWasCreated;
 use Spatie\Backup\Events\DumpingDatabase;
 use Spatie\Backup\Exceptions\BackupFailed;
 use Spatie\Backup\Exceptions\InvalidBackupJob;
-use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\Sqlite;
 use Spatie\DbDumper\DbDumper;
@@ -277,12 +276,6 @@ class BackupJob
                 }
 
                 $fileName = "{$dbType}-{$dbName}{$timeStamp}.{$this->getExtension($dbDumper)}";
-
-                // @todo is this still relevant or undocumented?
-                if (config('backup.backup.gzip_database_dump')) {
-                    $dbDumper->useCompressor(new GzipCompressor);
-                    $fileName .= '.'.$dbDumper->getCompressorExtension();
-                }
 
                 if ($compressor = $this->config->backup->databaseDumpCompressor) {
                     $dbDumper->useCompressor(new $compressor);

--- a/src/Tasks/Backup/FileSelection.php
+++ b/src/Tasks/Backup/FileSelection.php
@@ -145,10 +145,14 @@ class FileSelection
     protected function getMatchingPaths(string $path): array
     {
         if ($this->canUseGlobBrace($path)) {
-            return glob(str_replace('*', '{.[!.],}*', $path), GLOB_BRACE);
+            $result = @glob(str_replace('*', '{.[!.],}*', $path), GLOB_BRACE);
+
+            if ($result !== false) {
+                return $result;
+            }
         }
 
-        return glob($path);
+        return glob($path) ?: [];
     }
 
     protected function canUseGlobBrace(string $path): bool

--- a/src/Tasks/Backup/Zip.php
+++ b/src/Tasks/Backup/Zip.php
@@ -4,6 +4,7 @@ namespace Spatie\Backup\Tasks\Backup;
 
 use Illuminate\Support\Str;
 use Spatie\Backup\Config\Config;
+use Spatie\Backup\Exceptions\BackupFailed;
 use Spatie\Backup\Helpers\Format;
 use ZipArchive;
 
@@ -82,7 +83,11 @@ class Zip
 
     public function open(): void
     {
-        $this->zipFile->open($this->pathToZip, ZipArchive::CREATE);
+        $result = $this->zipFile->open($this->pathToZip, ZipArchive::CREATE);
+
+        if ($result !== true) {
+            throw BackupFailed::from(new \Exception("Failed to open zip file at '{$this->pathToZip}'. ZipArchive error code: {$result}"));
+        }
     }
 
     public function close(): void


### PR DESCRIPTION
ZipArchive::open() return value not checked causing silent backup failures
File handle resource leak in BackupDestination::write() on exceptions
glob() returning false causes type errors on Alpine Linux systems
GLOB_BRACE not supported on Alpine Linux causing backup failures
Undocumented legacy gzip_database_dump config removed