### PR TITLE
Fix: allows backups to continue when some destinations fail instead of failing completely

### DIFF
--- a/src/Config/DestinationConfig.php
+++ b/src/Config/DestinationConfig.php
@@ -17,6 +17,7 @@ class DestinationConfig extends Data
         public int $compressionLevel,
         public string $filenamePrefix,
         public array $disks,
+        public bool $continueOnFailure,
     ) {
         if ($compressionLevel > 9) {
             throw InvalidConfig::integerMustBeBetween('compression_level', 0, 9);
@@ -35,6 +36,7 @@ class DestinationConfig extends Data
             compressionLevel: $data['compression_level'] ?? 9,
             filenamePrefix: $data['filename_prefix'] ?? '',
             disks: $data['disks'] ?? ['local'],
+            continueOnFailure: $data['continue_on_failure'] ?? false,
         );
     }
 }


### PR DESCRIPTION
When trying to use the `continue_on_failure` configuration option, the application crashes with "Unknown named parameter $continueOnFailure" error. This happens because the DestinationConfig constructor is missing the parameter that the `fromArray()` method tries to pass to it.

Allows backups to continue when some destinations fail instead of failing completely 

 https://github.com/spatie/laravel-backup/issues/1932