### PR TITLE
Restore notification defaults for legacy single-server installs

### DIFF
--- a/src/Config/NotificationsConfig.php
+++ b/src/Config/NotificationsConfig.php
@@ -29,8 +29,8 @@ class NotificationsConfig extends Data
     public static function fromArray(array $data): self
     {
         return new self(
-            notifications: $data['notifications'],
-            notifiable: $data['notifiable'],
+            notifications: $data['notifications'] ?? [],
+            notifiable: $data['notifiable'] ?? Notifiable::class,
             mail: NotificationMailConfig::fromArray($data['mail']),
             slack: NotificationSlackConfig::fromArray($data['slack']),
             discord: isset($data['discord']) ? NotificationDiscordConfig::fromArray($data['discord']) : null,


### PR DESCRIPTION
fix: handle missing keys in NotificationsConfig array

- default `notifications` to an empty array and `notifiable` to the package class when missing
- keeps `NotificationsConfig::fromArray` resilient when only the channel sub-arrays are populated