### PR TITLE
Resolve cleanup strategy from the specified config when using --config

### DIFF
--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -40,6 +40,8 @@ class CleanupCommand extends BaseCommand implements Isolatable
 
         if ($this->option('config')) {
             $this->config = Config::fromArray(config($this->option('config')));
+
+            $this->strategy = app()->make($this->config->cleanup->strategy, ['config' => $this->config]);
         }
 
         try {

--- a/tests/Commands/CleanupCommandTest.php
+++ b/tests/Commands/CleanupCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Sleep;
 use Spatie\Backup\Events\CleanupWasSuccessful;
+use Spatie\Backup\Tests\TestSupport\FakeCleanupStrategy;
 
 beforeEach(function () {
     Event::fake();
@@ -216,4 +217,19 @@ it('can cleanup with specified configuration', function () {
     Storage::disk('local')->assertExists('mysite/test1.zip');
     Storage::disk('local')->assertExists('mysite/test2.zip');
     Storage::disk('local')->assertMissing('mysite/test3.zip');
+});
+
+it('uses the cleanup strategy from the specified configuration', function () {
+    FakeCleanupStrategy::$wasUsed = false;
+
+    config()->set('custom_backup', array_replace_recursive(
+        config('backup'),
+        ['cleanup' => ['strategy' => FakeCleanupStrategy::class]],
+    ));
+
+    $this->create1MbFileOnDisk('local', 'mysite/test1.zip', now()->subDays(1));
+
+    $this->artisan('backup:clean', ['--config' => 'custom_backup'])->assertExitCode(0);
+
+    expect(FakeCleanupStrategy::$wasUsed)->toBeTrue();
 });

--- a/tests/TestSupport/FakeCleanupStrategy.php
+++ b/tests/TestSupport/FakeCleanupStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Backup\Tests\TestSupport;
+
+use Spatie\Backup\BackupDestination\BackupCollection;
+use Spatie\Backup\Tasks\Cleanup\CleanupStrategy;
+
+class FakeCleanupStrategy extends CleanupStrategy
+{
+    public static bool $wasUsed = false;
+
+    public function deleteOldBackups(BackupCollection $backups): void
+    {
+        static::$wasUsed = true;
+    }
+}


### PR DESCRIPTION
Fixes #1975

## Problem

`backup:clean` always used the cleanup strategy from the default `backup.php` config, even when a different config file was passed with `--config`.

The strategy is bound once in the service provider:

```php
$this->app->bind(CleanupStrategy::class, config('backup.cleanup.strategy'));
```

So the instance injected into `CleanupCommand` is resolved from the default config and ignores `--config`. The command already reloads the config for the destinations, but the strategy was left pointing at the default one.

## Fix

When `--config` is supplied, re-resolve the cleanup strategy from that config's `cleanup.strategy`, passing the specified config to it so the strategy also runs against the right settings.

## Changes
- `CleanupCommand` re-resolves the strategy from the specified config when `--config` is used.
- Added a test asserting the strategy from the specified config is the one that runs, plus a `FakeCleanupStrategy` test fixture.