### PR TITLE
Fix PHPStan error in File::mimeType()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: src/Exceptions/CannotCreateDbDumper.php
 
 		-
-			message: '#^Call to function method_exists\(\) with Illuminate\\Contracts\\Filesystem\\Filesystem and ''mimeType'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Helpers/File.php
-
-		-
 			message: '#^Method Spatie\\Backup\\Notifications\\Channels\\Discord\\DiscordMessage\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -36,7 +36,7 @@ class File
     protected function mimeType(?Filesystem $disk, string $path): bool|string
     {
         try {
-            if ($disk && method_exists($disk, 'mimeType')) {
+            if ($disk) {
                 return $disk->mimeType($path) ?: false;
             }
         } catch (Exception) {


### PR DESCRIPTION
The `Illuminate\Contracts\Filesystem\Filesystem` contract now declares `mimeType()`, so the `method_exists($disk, 'mimeType')` guard always evaluates to `true`. PHPStan reports this (`function.alreadyNarrowedType`), and the matching baseline entry is no longer matched under current stable dependencies, which fails the `phpstan` CI job.

Since `$disk` is type-hinted as `Filesystem`, the method is guaranteed to exist. This drops the redundant `method_exists()` guard and removes the now obsolete baseline entry.

## Changes
- Remove redundant `method_exists()` check in `File::mimeType()`.
- Remove the corresponding stale entry from `phpstan-baseline.neon`.