### PR TITLE
Verify the archive file count against the manifest

### DIFF
--- a/src/Exceptions/BackupVerificationFailed.php
+++ b/src/Exceptions/BackupVerificationFailed.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Backup\Exceptions;
+
+use Exception;
+
+class BackupVerificationFailed extends Exception
+{
+    public static function couldNotOpenZip(string $pathToZip, int $errorCode): self
+    {
+        return new static("Backup verification failed: could not open the zip file at `{$pathToZip}`. ZipArchive error code: {$errorCode}.");
+    }
+
+    public static function zipIsEmpty(string $pathToZip): self
+    {
+        return new static("Backup verification failed: the zip file at `{$pathToZip}` is empty.");
+    }
+
+    public static function unexpectedFileCount(int $expectedFileCount, int $actualFileCount): self
+    {
+        return new static("Backup verification failed: expected {$expectedFileCount} files in the archive, but found {$actualFileCount}.");
+    }
+}

--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -17,6 +17,7 @@ use Spatie\Backup\Events\BackupWasSuccessful;
 use Spatie\Backup\Events\BackupZipWasCreated;
 use Spatie\Backup\Events\DumpingDatabase;
 use Spatie\Backup\Exceptions\BackupFailed;
+use Spatie\Backup\Exceptions\BackupVerificationFailed;
 use Spatie\Backup\Exceptions\InvalidBackupJob;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Databases\Sqlite;
@@ -274,14 +275,18 @@ class BackupJob
         $result = $zip->open($pathToZip, ZipArchive::RDONLY);
 
         if ($result !== true) {
-            throw new Exception("Backup verification failed: could not open zip file. Error code: {$result}");
+            throw BackupVerificationFailed::couldNotOpenZip($pathToZip, $result);
         }
 
         $actualCount = $zip->numFiles;
         $zip->close();
 
         if ($actualCount === 0) {
-            throw new Exception('Backup verification failed: zip file is empty.');
+            throw BackupVerificationFailed::zipIsEmpty($pathToZip);
+        }
+
+        if ($actualCount !== $expectedFileCount) {
+            throw BackupVerificationFailed::unexpectedFileCount($expectedFileCount, $actualCount);
         }
 
         backupLogger()->info("Backup verified: {$actualCount} files in archive.");

--- a/tests/Tasks/Backup/BackupVerificationTest.php
+++ b/tests/Tasks/Backup/BackupVerificationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Backup\Events\BackupHasFailed;
+use Spatie\Backup\Events\BackupZipWasCreated;
+use Spatie\Backup\Exceptions\BackupVerificationFailed;
+
+beforeEach(function () {
+    $this->setNow(2016, 1, 1, 21, 1, 1);
+
+    $this->expectedZipPath = 'mysite/2016-01-01-21-01-01.zip';
+
+    config()->set('backup.backup.destination.disks', ['local']);
+    config()->set('backup.backup.source.files.include', [$this->getStubDirectory()]);
+    config()->set('backup.backup.source.files.exclude', []);
+    config()->set('backup.backup.verify_backup', true);
+});
+
+it('completes the backup when the archive contains every file of the manifest', function () {
+    config()->set('backup.backup.source.databases', ['db1', 'db2']);
+
+    $this->artisan('backup:run')->assertExitCode(0);
+
+    Storage::disk('local')->assertExists($this->expectedZipPath);
+});
+
+it('fails the backup when the archive contains fewer files than the manifest', function () {
+    removeFirstFileFromCreatedZip();
+
+    $failure = null;
+    Event::listen(BackupHasFailed::class, function (BackupHasFailed $event) use (&$failure) {
+        $failure = $event->exception;
+    });
+
+    $this->artisan('backup:run --only-files')
+        ->expectsOutputToContain('Backup verification failed')
+        ->assertExitCode(1);
+
+    expect($failure)->toBeInstanceOf(BackupVerificationFailed::class);
+
+    Storage::disk('local')->assertMissing($this->expectedZipPath);
+});
+
+it('does not verify the archive when verification is disabled', function () {
+    config()->set('backup.backup.verify_backup', false);
+
+    removeFirstFileFromCreatedZip();
+
+    $this->artisan('backup:run --only-files')->assertExitCode(0);
+
+    Storage::disk('local')->assertExists($this->expectedZipPath);
+});
+
+function removeFirstFileFromCreatedZip(): void
+{
+    Event::listen(BackupZipWasCreated::class, function (BackupZipWasCreated $event) {
+        $zip = new ZipArchive;
+
+        $zip->open($event->pathToZip);
+        $zip->deleteIndex(0);
+        $zip->close();
+    });
+}


### PR DESCRIPTION
`verifyBackup()` took an `$expectedFileCount` argument but never compared it to the archive's actual entry count, so it only caught unopenable or completely empty zips. It now throws when the counts differ.

Reported by @gazben in https://github.com/spatie/laravel-backup/pull/1957#issuecomment-5102107468.